### PR TITLE
Add configurable global popup duration and colour

### DIFF
--- a/Rules/Scripts/Utilities/GlobalPopup.as
+++ b/Rules/Scripts/Utilities/GlobalPopup.as
@@ -6,7 +6,8 @@ const string POP_START_KEY    = "popup_start";
 const string POP_COLOR_KEY    = "popup_color";
 const string POP_DURATION_KEY = "popup_duration";
 
-const u16    POP_DEFAULT_DURATION = 8 * getTicksASecond(); // 8 seconds
+// Default popup duration in ticks (10 seconds)
+const u16    POP_DEFAULT_DURATION = 10 * getTicksASecond();
 const SColor POP_DEFAULT_COLOR(255, 255, 240, 0);          // warm yellow
 
 // ---- SERVER API ----

--- a/Rules/Scripts/Weather/WeatherSystem.as
+++ b/Rules/Scripts/Weather/WeatherSystem.as
@@ -101,8 +101,8 @@ void ChangeRainLevel(CRules@ this, int newLevel)
 	// Show storm popup when entering level 4 (centralized popup)
 	if (newLevel == 4 && oldLevel != 4)
 	{
-		Server_GlobalPopup(this, "⚡ You hear an intense storm approaching ⚡",
-		                   SColor(255, 255, 240, 0), 8 * getTicksASecond());
+                Server_GlobalPopup(this, "⚡ You hear an intense storm approaching ⚡",
+                                   SColor(255, 255, 240, 0), 10 * getTicksASecond());
 	}
 	
 	print("Weather: Changing rain level from " + oldLevel + " to " + newLevel);

--- a/Rules/Scripts/Zombies/Zombies_Boss.as
+++ b/Rules/Scripts/Zombies/Zombies_Boss.as
@@ -1,5 +1,5 @@
 // Zombies_Boss.as
-void server_SendGlobalMessage(const string &in msg);
+#include "GlobalPopup.as"
 int RunBossWave(const int dayNumber,
                 const float zombdiff,
                 Vec2f[]@ zombiePlaces,
@@ -19,20 +19,26 @@ int RunBossWave(const int dayNumber,
 			server_CreateBlob("horror", -1, sp);
 			server_CreateBlob("horror", -1, sp);
 			Sound::Play("/dontyoudare.ogg");
-                        server_SendGlobalMessage("A mini boss has spawned!\n3x Horrors\n16 Hearts, Spawns 3 Special Zombies.");
+                        Server_GlobalPopup(getRules(),
+                                           "A mini boss has spawned!\n3x Horrors\n16 Hearts, Spawns 3 Special Zombies.",
+                                           SColor(255, 255, 0, 0), 10 * getTicksASecond());
 		}
 		else if (boss <= 20)
 		{
 			server_CreateBlob("pbanshee", -1, sp);
 			server_CreateBlob("pbanshee", -1, sp);
 			Sound::Play("/dontyoudare.ogg");
-                        server_SendGlobalMessage("A mini boss has spawned!\n2x Banshee\n10 Explosion Blast\n30 Block Stunning scream.");
+                        Server_GlobalPopup(getRules(),
+                                           "A mini boss has spawned!\n2x Banshee\n10 Explosion Blast\n30 Block Stunning scream.",
+                                           SColor(255, 255, 0, 0), 10 * getTicksASecond());
 		}
 		else if (boss <= 30)
 		{
 			server_CreateBlob("writher", -1, sp);
 			Sound::Play("/dontyoudare.ogg");
-                        server_SendGlobalMessage("A mini boss has spawned!\n1x Writhers\n20 Explosion Blast\nSpawns 2 Wraiths on death.");
+                        Server_GlobalPopup(getRules(),
+                                           "A mini boss has spawned!\n1x Writhers\n20 Explosion Blast\nSpawns 2 Wraiths on death.",
+                                           SColor(255, 255, 0, 0), 10 * getTicksASecond());
 		}
 		else if (boss <= 40)
 		{
@@ -45,20 +51,26 @@ int RunBossWave(const int dayNumber,
 			server_CreateBlob("zbison", -1, sp);
 			server_CreateBlob("zbison2", -1, sp);
 			Sound::Play("/dontyoudare.ogg");
-                        server_SendGlobalMessage("A mini boss has spawned!\nA Horde of Bison\n10 Hearts, 1 Dmg.");
+                        Server_GlobalPopup(getRules(),
+                                           "A mini boss has spawned!\nA Horde of Bison\n10 Hearts, 1 Dmg.",
+                                           SColor(255, 255, 0, 0), 10 * getTicksASecond());
 		}
 		else if (boss <= 50)
 		{
 			for (int i = 0; i < 16; i++) server_CreateBlob("immolator", -1, sp);
 			Sound::Play("/dontyoudare.ogg");
-                        server_SendGlobalMessage("A mini boss has spawned!\n16x immolator\n7 Explosion Blast.");
+                        Server_GlobalPopup(getRules(),
+                                           "A mini boss has spawned!\n16x immolator\n7 Explosion Blast.",
+                                           SColor(255, 255, 0, 0), 10 * getTicksASecond());
 		}
 		else if (boss <= 60)
 		{
 			server_CreateBlob("abomination", -1, sp);
 			server_CreateBlob("abomination", -1, sp);
 			Sound::Play("/dontyoudare.ogg");
-                        server_SendGlobalMessage("A Boss has spawned!\n2x Abominations\n60 Hearts, 4 Dmg.");
+                        Server_GlobalPopup(getRules(),
+                                           "A Boss has spawned!\n2x Abominations\n60 Hearts, 4 Dmg.",
+                                           SColor(255, 255, 0, 0), 10 * getTicksASecond());
 		}
 		else if (boss <= 120)
 		{
@@ -66,7 +78,9 @@ int RunBossWave(const int dayNumber,
 			server_CreateBlob("writher", -1, sp);
 			server_CreateBlob("writher", -1, sp);
 			Sound::Play("/dontyoudare.ogg");
-                        server_SendGlobalMessage("A Boss has spawned!\n3x Writhers\n20 Explosion Blast\nSpawns 2 Wraiths on death.");
+                        Server_GlobalPopup(getRules(),
+                                           "A Boss has spawned!\n3x Writhers\n20 Explosion Blast\nSpawns 2 Wraiths on death.",
+                                           SColor(255, 255, 0, 0), 10 * getTicksASecond());
 		}
 	}
 

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -4,6 +4,7 @@
 #include "RespawnSystem.as"
 #include "Zombies_Boss.as"
 #include "Zombies_Utils.as"
+#include "GlobalPopup.as"
 
 class ZombiesCore : RulesCore
 {
@@ -76,12 +77,9 @@ class ZombiesCore : RulesCore
 		const int max_undead = (num_survivors_p/3);
 		rules.set_s32("max_undead", max_undead);
 
-		// old center message: clear it so nothing shows in the middle
-		rules.SetGlobalMessage("");
-
-		// also stash a couple values for the HUD renderer
-		rules.set_s32("hud_dayNumber", dayNumber);
-		rules.set_s32("hud_ignore_light", ignore_light);
+                // also stash a couple values for the HUD renderer
+                rules.set_s32("hud_dayNumber", dayNumber);
+                rules.set_s32("hud_ignore_light", ignore_light);
 
 		if (rules.isWarmup() && timeElapsed > getTicksASecond()*30)
 			rules.SetCurrentState(GAME);
@@ -234,12 +232,14 @@ class ZombiesCore : RulesCore
 		CBlob@[] bases; getBlobsByName(base_name(), @bases);
 		const int num_survivors = rules.get_s32("num_survivors");
 
-		if (bases.length == 0)
-		{
-			rules.SetTeamWon(1);
-			rules.SetCurrentState(GAME_OVER);
-			rules.SetGlobalMessage("Gameover!\nThe Pillars Have Been destroyed\nOn day " + (dayNumber + days_offset) + ".");
-		}
+                if (bases.length == 0)
+                {
+                        rules.SetTeamWon(1);
+                        rules.SetCurrentState(GAME_OVER);
+                        Server_GlobalPopup(rules,
+                                           "Gameover!\nThe Pillars Have Been destroyed\nOn day " + (dayNumber + days_offset) + ".",
+                                           SColor(255, 255, 0, 0), 10 * getTicksASecond());
+                }
 	}
 	void addKill(int team)
 	{


### PR DESCRIPTION
## Summary
- allow specifying popup color and duration with a 10s default
- use the popup system for boss waves, weather alerts and gameover messages

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2c134c0488333a73a4cb4ccd15f8b