### PR TITLE
Ensure survivor respawns at midday

### DIFF
--- a/Rules/Config/gamemode.cfg
+++ b/Rules/Config/gamemode.cfg
@@ -51,7 +51,7 @@ scripts              = KAG.as;
 
 
 daycycle_speed       = 3.5          # 1 day = X minutes; 0 = no cycle
-daycycle_start       = 0.3           # 0.0 = midnight; 0.5 = midday; 1.0 = midnight
+daycycle_start       = 0.5           # 0.0 = midnight; 0.5 = midday; 1.0 = midnight
 
 autoassign_teams     = no            # team allocation is not smart in this gamemode
 auto_bots            = no

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -266,12 +266,13 @@ class ZombiesCore : RulesCore
 		warn("sync");
 	}
 
-	void onPlayerDie(CPlayer@ victim, CPlayer@ killer, u8 customData)
-	{
-		if (!rules.isMatchRunning()) return;
-		if (victim !is null && killer !is null && killer.getTeamNum() != victim.getTeamNum())
-			addKill(killer.getTeamNum());
-	}
+        void onPlayerDie(CPlayer@ victim, CPlayer@ killer, u8 customData)
+        {
+                RulesCore::onPlayerDie(victim, killer, customData);
+                if (!rules.isMatchRunning()) return;
+                if (victim !is null && killer !is null && killer.getTeamNum() != victim.getTeamNum())
+                        addKill(killer.getTeamNum());
+        }
 
 	void Zombify(CPlayer@ player)
 	{

--- a/Rules/Scripts/Zombies/Zombies_Spawns.as
+++ b/Rules/Scripts/Zombies/Zombies_Spawns.as
@@ -236,15 +236,17 @@ class ZombiesSpawns : RespawnSystem
 	{
 		getRules().Sync("gold_structures", true);
 		s32 tickspawndelay = 0;
-		if (player.getDeaths() != 0)
-		{
-			int gamestart = getRules().get_s32("gamestart");
-			int day_cycle = getRules().daycycle_speed * 60;
-			int timeElapsed = ((getGameTime() - gamestart) / getTicksASecond()) % day_cycle;
-			int spawnlimit = (((getGameTime() - gamestart) / getTicksASecond() / day_cycle) + 1) * 300;
-			tickspawndelay = Maths::Min((60 * 30), ((day_cycle - timeElapsed) * getTicksASecond()));
-			if (timeElapsed < 30) tickspawndelay = 0;
-		}
+                if (player.getDeaths() != 0)
+                {
+                        int gamestart = getRules().get_s32("gamestart");
+                        int day_cycle = getRules().daycycle_speed * 60;
+                        int timeElapsed = ((getGameTime() - gamestart) / getTicksASecond()) % day_cycle;
+                        int half_day = day_cycle / 2;
+                        int seconds_to_midday = timeElapsed <= half_day
+                                               ? (half_day - timeElapsed)
+                                               : (day_cycle - timeElapsed + half_day);
+                        tickspawndelay = Maths::Min((60 * 30), seconds_to_midday * getTicksASecond());
+                }
 
 		CTFPlayerInfo@ info = cast<CTFPlayerInfo@>(core.getInfoFromPlayer(player));
 


### PR DESCRIPTION
## Summary
- Call base onPlayerDie so dead players are queued for respawn
- Delay player respawn until midday
- Start the day cycle at midday by default

## Testing
- `./run-tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a363d8d2d88333bc7da557db8014a3