### PR TITLE
Ensure survivors respawn and show revival timer

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -269,7 +269,14 @@ class ZombiesCore : RulesCore
         void onPlayerDie(CPlayer@ victim, CPlayer@ killer, u8 customData)
         {
                 RulesCore::onPlayerDie(victim, killer, customData);
+
+                if (victim !is null)
+                {
+                        Zombies_spawns.AddPlayerToSpawn(victim);
+                }
+
                 if (!rules.isMatchRunning()) return;
+
                 if (victim !is null && killer !is null && killer.getTeamNum() != victim.getTeamNum())
                         addKill(killer.getTeamNum());
         }

--- a/Rules/Scripts/Zombies/Zombies_Interface.as
+++ b/Rules/Scripts/Zombies/Zombies_Interface.as
@@ -50,9 +50,9 @@ void DrawRevivalTimer(CRules@ this, CPlayer@ p)
 			{
 				GUI::SetFont("menu");
 				Vec2f pos(getScreenWidth()/2 - 70, getScreenHeight()/3 + Maths::Sin(getGameTime() / 3.0f) * 5.0f);
-				GUI::DrawText("Revival in: " + spawn, pos, SColor(255, 255, 255, 55));
-			}
-		}
+                                GUI::DrawText("Revival in: " + spawn + "s", pos, SColor(255, 255, 255, 55));
+                        }
+                }
 	}
 }
 


### PR DESCRIPTION
## Summary
- Requeue dead players for respawn and track spawn times
- Display revival countdown with seconds on HUD

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68a370cc03c483339e36d1408e7576fa