### PR TITLE
Refactor target info setup and clean indentation

### DIFF
--- a/Entities/NPCs/AirElemental/AirElemental.as
+++ b/Entities/NPCs/AirElemental/AirElemental.as
@@ -11,22 +11,15 @@ const int COINS_ON_DEATH = 0;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
+	addTargetInfo(infos, "undeadplayer", 1.0f, true, true);
+	addTargetInfo(infos, "zombie", 0.5f, true);
 
-	{
-		TargetInfo i("undeadplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("zombie", 0.5f, true);
-		infos.push_back(i);
-	}	
-	
 	//for EatOthers
 	string[] tags = {"dead"};
 	this.set("tags to eat", tags);
-	
+
 	this.set_f32("bite damage", 0.5f);
-	
+
 	this.set("target infos", infos);
 	
 	this.set_u8("attack frequency", ATTACK_FREQUENCY);
@@ -39,13 +32,13 @@ void onInit(CBlob@ this)
 	this.SetLightRadius(64.0f);
 	this.SetLightColor(SColor(255, 81, 132, 19));	
 
-    this.getSprite().PlayRandomSound("/AirDie");
+	this.getSprite().PlayRandomSound("/AirDie");
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	
 	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	this.getCurrentScript().removeIfTag = "dead";
@@ -90,5 +83,5 @@ void onDie( CBlob@ this )
 {
 	server_DropCoins(this.getPosition() + Vec2f(0, -3.0f), COINS_ON_DEATH);
 
-    this.getSprite().PlaySound("AirDie");	
+	this.getSprite().PlaySound("AirDie");	
 }

--- a/Entities/NPCs/EarthElemental/EarthElemental.as
+++ b/Entities/NPCs/EarthElemental/EarthElemental.as
@@ -11,22 +11,15 @@ const int COINS_ON_DEATH = 0;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
+	addTargetInfo(infos, "undeadplayer", 1.0f, true, true);
+	addTargetInfo(infos, "zombie", 0.5f, true);
 
-	{
-		TargetInfo i("undeadplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("zombie", 0.5f, true);
-		infos.push_back(i);
-	}	
-	
 	//for EatOthers
 	string[] tags = {"dead"};
 	this.set("tags to eat", tags);
-	
+
 	this.set_f32("bite damage", 0.5f);
-	
+
 	this.set("target infos", infos);
 	
 	this.set_u8("attack frequency", ATTACK_FREQUENCY);
@@ -39,13 +32,13 @@ void onInit(CBlob@ this)
 	this.SetLightRadius(64.0f);
 	this.SetLightColor(SColor(255, 100, 113, 96));	
 
-    this.getSprite().PlayRandomSound("WoodHeavyBump");
+	this.getSprite().PlayRandomSound("WoodHeavyBump");
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	
 	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	this.getCurrentScript().removeIfTag = "dead";
@@ -90,5 +83,5 @@ void onDie( CBlob@ this )
 {
 	server_DropCoins(this.getPosition() + Vec2f(0, -3.0f), COINS_ON_DEATH);
 
-    this.getSprite().PlaySound("WoodDestruct");	
+	this.getSprite().PlaySound("WoodDestruct");	
 }

--- a/Entities/NPCs/FireElemental/FireElemental.as
+++ b/Entities/NPCs/FireElemental/FireElemental.as
@@ -11,22 +11,15 @@ const int COINS_ON_DEATH = 0;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
+	addTargetInfo(infos, "undeadplayer", 1.0f, true, true);
+	addTargetInfo(infos, "zombie", 0.5f, true);
 
-	{
-		TargetInfo i("undeadplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("zombie", 0.5f, true);
-		infos.push_back(i);
-	}	
-	
 	//for EatOthers
 	string[] tags = {"dead"};
 	this.set("tags to eat", tags);
-	
+
 	this.set_f32("bite damage", 0.5f);
-	
+
 	this.set("target infos", infos);
 	
 	this.set_u8("attack frequency", ATTACK_FREQUENCY);
@@ -40,13 +33,13 @@ void onInit(CBlob@ this)
 	this.SetLightRadius(64.0f);
 	this.SetLightColor(SColor(255, 255, 240, 171));	
 
-    this.getSprite().PlayRandomSound("/GreatCombustion");
+	this.getSprite().PlayRandomSound("/GreatCombustion");
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	
 	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	this.getCurrentScript().removeIfTag = "dead";
@@ -91,5 +84,5 @@ void onDie( CBlob@ this )
 {
 	server_DropCoins(this.getPosition() + Vec2f(0, -3.0f), COINS_ON_DEATH);
 
-    this.getSprite().PlaySound("Bomb.ogg");	
+	this.getSprite().PlaySound("Bomb.ogg");	
 }

--- a/Entities/NPCs/Raven/Raven.as
+++ b/Entities/NPCs/Raven/Raven.as
@@ -11,26 +11,16 @@ const int COINS_ON_DEATH = 0;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
+	addTargetInfo(infos, "undeadplayer", 1.0f, true, true);
+	addTargetInfo(infos, "enemy", 0.9f, true);
+	addTargetInfo(infos, "dead", 0.5f, true);
 
-	{
-		TargetInfo i("undeadplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("enemy", 0.9f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("dead", 0.5f, true);
-		infos.push_back(i);
-	}	
-	
 	//for EatOthers
 	string[] tags = {"dead"};
 	this.set("tags to eat", tags);
-	
+
 	this.set_f32("bite damage", 0.5f);
-	
+
 	this.set("target infos", infos);
 	
 	this.set_u8("attack frequency", ATTACK_FREQUENCY);
@@ -43,13 +33,13 @@ void onInit(CBlob@ this)
 	this.SetLightRadius(64.0f);
 	this.SetLightColor(SColor(255, 255, 240, 171));	
 
-    this.getSprite().PlayRandomSound("/ScaredChicken01");
+	this.getSprite().PlayRandomSound("/ScaredChicken01");
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	
 	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	this.getCurrentScript().removeIfTag = "dead";
@@ -94,5 +84,5 @@ void onDie( CBlob@ this )
 {
 	server_DropCoins(this.getPosition() + Vec2f(0, -3.0f), COINS_ON_DEATH);
 
-    this.getSprite().PlaySound("ScaredChicken03.ogg");	
+	this.getSprite().PlaySound("ScaredChicken03.ogg");	
 }

--- a/Entities/NPCs/WaterElemental/WaterElemental.as
+++ b/Entities/NPCs/WaterElemental/WaterElemental.as
@@ -11,21 +11,14 @@ const int COINS_ON_DEATH = 0;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("undeadplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("zombie", 0.5f, true);
-		infos.push_back(i);
-	}	
+	addTargetInfo(infos, "undeadplayer", 1.0f, true, true);
+	addTargetInfo(infos, "zombie", 0.5f, true);
 
 	//for EatOthers
 	string[] tags = {"dead"};
 	this.set("tags to eat", tags);
-	
-	this.set_f32("bite damage", 0.5f);	
+
+	this.set_f32("bite damage", 0.5f);
 
 	this.set("target infos", infos);
 	
@@ -40,13 +33,13 @@ void onInit(CBlob@ this)
 	this.SetLightRadius(64.0f);
 	this.SetLightColor(SColor(255, 25, 94, 157));	
 
-    this.getSprite().PlayRandomSound("WaterBubble1");
+	this.getSprite().PlayRandomSound("WaterBubble1");
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	
 	this.getCurrentScript().runFlags |= Script::tick_not_attached;
 	this.getCurrentScript().removeIfTag = "dead";
@@ -91,5 +84,5 @@ void onDie( CBlob@ this )
 {
 	server_DropCoins(this.getPosition() + Vec2f(0, -3.0f), COINS_ON_DEATH);
 
-    this.getSprite().PlaySound("GlassBreak");	
+	this.getSprite().PlaySound("GlassBreak");	
 }

--- a/Entities/Zombies/Greg/Greg.as
+++ b/Entities/Zombies/Greg/Greg.as
@@ -7,31 +7,24 @@ const int COINS_ON_DEATH = 25;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
+	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+	addTargetInfo(infos, "mage", 0.9f);
 
-	{
-		TargetInfo i("survivorplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mage", 0.9f);
-		infos.push_back(i);
-	}	
-	
 	this.set("target infos", @infos);
 
 	this.set_u16("coins on death", COINS_ON_DEATH);
 	this.set_f32(target_searchrad_property, 512.0f);
 
-    this.getSprite().SetEmitSound("Wings.ogg");
-    this.getSprite().SetEmitSoundPaused(false);
+	this.getSprite().SetEmitSound("Wings.ogg");
+	this.getSprite().SetEmitSoundPaused(false);
 
-    this.getSprite().PlayRandomSound("/GregCry");
+	this.getSprite().PlayRandomSound("/GregCry");
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	this.Tag("zombie");
 	this.Tag("enemy");
 	this.Tag("gregs");
@@ -74,5 +67,5 @@ f32 onHit( CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hit
 
 void onDie( CBlob@ this )
 {
-    this.getSprite().PlaySound("/GregRoar");	
+	this.getSprite().PlaySound("/GregRoar");	
 }

--- a/Entities/Zombies/Greg/Greg2.as
+++ b/Entities/Zombies/Greg/Greg2.as
@@ -7,31 +7,24 @@ const int COINS_ON_DEATH = 25;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
+	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+	addTargetInfo(infos, "mage", 0.9f);
 
-	{
-		TargetInfo i("survivorplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mage", 0.9f);
-		infos.push_back(i);
-	}	
-	
 	this.set("target infos", @infos);
 
 	this.set_u16("coins on death", COINS_ON_DEATH);
 	this.set_f32(target_searchrad_property, 512.0f);
 
-    this.getSprite().SetEmitSound("Wings.ogg");
-    this.getSprite().SetEmitSoundPaused(false);
+	this.getSprite().SetEmitSound("Wings.ogg");
+	this.getSprite().SetEmitSoundPaused(false);
 
-    this.getSprite().PlayRandomSound("/GregCry");
+	this.getSprite().PlayRandomSound("/GregCry");
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	this.Tag("zombie");
 	this.Tag("enemy");
 	this.Tag("gregs");
@@ -75,5 +68,5 @@ f32 onHit( CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hit
 
 void onDie( CBlob@ this )
 {
-    this.getSprite().PlaySound("/GregRoar");	
+	this.getSprite().PlaySound("/GregRoar");	
 }

--- a/Entities/Zombies/Immolator/Immolator.as
+++ b/Entities/Zombies/Immolator/Immolator.as
@@ -9,47 +9,28 @@ const int COINS_ON_DEATH = 10;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("survivorplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("pet", 0.9f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("lantern", 0.9f);
-		infos.push_back(i);		
-	}
-	{
-		TargetInfo i("stone_door", 0.6f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_door", 0.6f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("survivorbuilding", 0.6f, true);
-		infos.push_back(i);
-	}		
+	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+	addTargetInfo(infos, "pet", 0.9f, true);
+	addTargetInfo(infos, "lantern", 0.9f);
+	addTargetInfo(infos, "stone_door", 0.6f);
+	addTargetInfo(infos, "wooden_door", 0.6f);
+	addTargetInfo(infos, "survivorbuilding", 0.6f, true);
 
 	this.set("target infos", infos);
 
 	this.set_u16("coins on death", COINS_ON_DEATH);
 	this.set_f32(target_searchrad_property, 512.0f);
 
-    this.getSprite().PlaySound("WraithSpawn.ogg");
+	this.getSprite().PlaySound("WraithSpawn.ogg");
 
-    this.getSprite().SetEmitSound("WraithFly.ogg");
-    this.getSprite().SetEmitSoundPaused(false);
+	this.getSprite().SetEmitSound("WraithFly.ogg");
+	this.getSprite().SetEmitSoundPaused(false);
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 	
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	this.Tag("zombie");
 	this.Tag("enemy");
 	
@@ -79,7 +60,7 @@ void onTick(CBlob@ this)
 			this.Tag("exploding");
 		    this.set_s32("explosion_timer", getGameTime() + TIME_TO_EXPLODE);
 
-            this.getSprite().PlaySound("/ImmolatorDie");
+	this.getSprite().PlaySound("/ImmolatorDie");
 		}
 
 		if (getNet().isServer())
@@ -88,15 +69,15 @@ void onTick(CBlob@ this)
        	 	if (timer <= 0)
         	{
             	// boom
-                this.server_SetHealth(-1.0f);
-                this.server_Die();
+	this.server_SetHealth(-1.0f);
+	this.server_Die();
             }
 		}
 		else
 		{
-            this.SetLight( true );
-            this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
-            this.SetLightColor( SColor(255, 211, 121, 224) );
+	this.SetLight( true );
+	this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
+	this.SetLightColor( SColor(255, 211, 121, 224) );
 
             if (XORRandom(128) == 0)
             {

--- a/Entities/Zombies/Scripts/CreatureCommon.as
+++ b/Entities/Zombies/Scripts/CreatureCommon.as
@@ -44,6 +44,11 @@ shared class TargetInfo
     }
 }
 
+void addTargetInfo(TargetInfo[]@ infos, const string &in identifier, f32 priority = 0.5f, bool tag = false, bool seeThroughWalls = false)
+{
+    infos.push_back(TargetInfo(identifier, priority, tag, seeThroughWalls));
+}
+
 shared class CreatureMoveVars
 {
     //walking vars

--- a/Entities/Zombies/Scripts/TagAsLargeZombie.as
+++ b/Entities/Zombies/Scripts/TagAsLargeZombie.as
@@ -11,66 +11,23 @@ void onInit( CBlob@ this )
 void SetupTargets( CBlob@ this )
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("survivorplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("migrantbot", 1.0f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("ally", 0.9f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("survivormechanism", 0.9f);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("survivorbuilding", 0.8f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("stone_door", 0.6f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mounted_bow", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mounted_bazooka", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_door", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_platform", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("pet", 0.2f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("lantern", 0.2f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("medium_zombie", 0.2f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("lesser_zombie", 0.2f);
-		infos.push_back(i);
-	}
+	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+	addTargetInfo(infos, "migrantbot", 1.0f, true);
+	addTargetInfo(infos, "ally", 0.9f, true);
+	addTargetInfo(infos, "survivormechanism", 0.9f);
+	addTargetInfo(infos, "survivorbuilding", 0.8f, true);
+	addTargetInfo(infos, "stone_door", 0.6f);
+	addTargetInfo(infos, "mounted_bow", 0.4f);
+	addTargetInfo(infos, "mounted_bazooka", 0.4f);
+	addTargetInfo(infos, "wooden_door", 0.4f);
+	addTargetInfo(infos, "wooden_platform", 0.4f);
+	addTargetInfo(infos, "pet", 0.2f, true);
+	addTargetInfo(infos, "lantern", 0.2f);
+	addTargetInfo(infos, "medium_zombie", 0.2f);
+	addTargetInfo(infos, "lesser_zombie", 0.2f);
 
 	this.set("target infos", infos);
-	
+
 	//for EatOthers
 	string[] tags = {"dead"};
 	this.set("tags to eat", tags);

--- a/Entities/Zombies/Scripts/TagAsLesserZombie.as
+++ b/Entities/Zombies/Scripts/TagAsLesserZombie.as
@@ -11,50 +11,19 @@ void onInit( CBlob@ this )
 void SetupTargets( CBlob@ this )
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("survivorplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("migrantbot", 1.0f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("ally", 0.9f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("survivorbuilding", 0.8f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mounted_bow", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mounted_bazooka", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_door", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_platform", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("pet", 0.2f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("lantern", 0.2f);
-		infos.push_back(i);
-	}
+	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+	addTargetInfo(infos, "migrantbot", 1.0f, true);
+	addTargetInfo(infos, "ally", 0.9f, true);
+	addTargetInfo(infos, "survivorbuilding", 0.8f, true);
+	addTargetInfo(infos, "mounted_bow", 0.4f);
+	addTargetInfo(infos, "mounted_bazooka", 0.4f);
+	addTargetInfo(infos, "wooden_door", 0.4f);
+	addTargetInfo(infos, "wooden_platform", 0.4f);
+	addTargetInfo(infos, "pet", 0.2f, true);
+	addTargetInfo(infos, "lantern", 0.2f);
 
 	this.set("target infos", infos);
-	
+
 	//for EatOthers
 	string[] tags = {"dead"};
 	this.set("tags to eat", tags);

--- a/Entities/Zombies/Scripts/TagAsMediumZombie.as
+++ b/Entities/Zombies/Scripts/TagAsMediumZombie.as
@@ -11,54 +11,20 @@ void onInit( CBlob@ this )
 void SetupTargets( CBlob@ this )
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("survivorplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("migrantbot", 1.0f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("ally", 0.9f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("survivorbuilding", 0.8f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mounted_bow", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mounted_bazooka", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_door", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_platform", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("pet", 0.2f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("lantern", 0.2f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("lesser_zombie", 0.2f);
-		infos.push_back(i);
-	}
+	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+	addTargetInfo(infos, "migrantbot", 1.0f, true);
+	addTargetInfo(infos, "ally", 0.9f, true);
+	addTargetInfo(infos, "survivorbuilding", 0.8f, true);
+	addTargetInfo(infos, "mounted_bow", 0.4f);
+	addTargetInfo(infos, "mounted_bazooka", 0.4f);
+	addTargetInfo(infos, "wooden_door", 0.4f);
+	addTargetInfo(infos, "wooden_platform", 0.4f);
+	addTargetInfo(infos, "pet", 0.2f, true);
+	addTargetInfo(infos, "lantern", 0.2f);
+	addTargetInfo(infos, "lesser_zombie", 0.2f);
 
 	this.set("target infos", infos);
-	
+
 	//for EatOthers
 	string[] tags = {"dead"};
 	this.set("tags to eat", tags);

--- a/Entities/Zombies/Scripts/TagAsNecromancerZombie.as
+++ b/Entities/Zombies/Scripts/TagAsNecromancerZombie.as
@@ -11,54 +11,20 @@ void onInit( CBlob@ this )
 void SetupTargets( CBlob@ this )
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("survivorplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("migrantbot", 1.0f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("ally", 0.9f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("survivorbuilding", 0.8f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("stone_door", 0.6f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mounted_bow", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mounted_bazooka", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_door", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_platform", 0.4f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("pet", 0.2f, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("lantern", 0.2f);
-		infos.push_back(i);
-	}
+	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+	addTargetInfo(infos, "migrantbot", 1.0f, true);
+	addTargetInfo(infos, "ally", 0.9f, true);
+	addTargetInfo(infos, "survivorbuilding", 0.8f, true);
+	addTargetInfo(infos, "stone_door", 0.6f);
+	addTargetInfo(infos, "mounted_bow", 0.4f);
+	addTargetInfo(infos, "mounted_bazooka", 0.4f);
+	addTargetInfo(infos, "wooden_door", 0.4f);
+	addTargetInfo(infos, "wooden_platform", 0.4f);
+	addTargetInfo(infos, "pet", 0.2f, true);
+	addTargetInfo(infos, "lantern", 0.2f);
 
 	this.set("target infos", infos);
-	
+
 	//for EatOthers
 	string[] tags = {"dead"};
 	this.set("tags to eat", tags);

--- a/Entities/Zombies/Wraith/Wraith.as
+++ b/Entities/Zombies/Wraith/Wraith.as
@@ -9,47 +9,28 @@ const int COINS_ON_DEATH = 10;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("survivorplayer", 0.8f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("pet", 0.9f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("lantern", 0.9f);
-		infos.push_back(i);		
-	}
-	{
-		TargetInfo i("stone_door", 1.0f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_door", 0.9f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("survivorbuilding", 0.6f, true);
-		infos.push_back(i);
-	}		
+	addTargetInfo(infos, "survivorplayer", 0.8f, true, true);
+	addTargetInfo(infos, "pet", 0.9f, true);
+	addTargetInfo(infos, "lantern", 0.9f);
+	addTargetInfo(infos, "stone_door", 1.0f);
+	addTargetInfo(infos, "wooden_door", 0.9f);
+	addTargetInfo(infos, "survivorbuilding", 0.6f, true);
 
 	this.set("target infos", infos);
 
 	this.set_u16("coins on death", COINS_ON_DEATH);
 	this.set_f32(target_searchrad_property, 512.0f);
 
-    this.getSprite().PlaySound("WraithSpawn.ogg");
+	this.getSprite().PlaySound("WraithSpawn.ogg");
 
-    this.getSprite().SetEmitSound("WraithFly.ogg");
-    this.getSprite().SetEmitSoundPaused(false);
+	this.getSprite().SetEmitSound("WraithFly.ogg");
+	this.getSprite().SetEmitSoundPaused(false);
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 	
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	this.Tag("zombie");
 	this.Tag("enemy");
 	this.Tag("wraiths");
@@ -77,7 +58,7 @@ void onTick(CBlob@ this)
 			this.Tag("exploding");
 		    this.set_s32("explosion_timer", getGameTime() + TIME_TO_EXPLODE);
 
-            this.getSprite().PlaySound("/WraithDie");
+	this.getSprite().PlaySound("/WraithDie");
 		}
 
 		if (getNet().isServer())
@@ -86,15 +67,15 @@ void onTick(CBlob@ this)
        	 	if (timer <= 0)
         	{
             	// boom
-                this.server_SetHealth(-1.0f);
-                this.server_Die();
+	this.server_SetHealth(-1.0f);
+	this.server_Die();
             }
 		}
 		else
 		{
-            this.SetLight( true );
-            this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
-            this.SetLightColor( SColor(255, 211, 121, 224) );
+	this.SetLight( true );
+	this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
+	this.SetLightColor( SColor(255, 211, 121, 224) );
 
             if (XORRandom(128) == 0)
             {

--- a/Entities/Zombies/Wraith/Wraith2.as
+++ b/Entities/Zombies/Wraith/Wraith2.as
@@ -9,27 +9,23 @@ const int COINS_ON_DEATH = 0;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("survivorplayer", 1.0f, true);
-		infos.push_back(i);
-	}	
+	addTargetInfo(infos, "survivorplayer", 1.0f, true);
 
 	this.set("target infos", infos);
 
 	this.set_u16("coins on death", COINS_ON_DEATH);
 	this.set_f32(target_searchrad_property, 512.0f);
 
-    this.getSprite().PlaySound("WraithSpawn.ogg");
+	this.getSprite().PlaySound("WraithSpawn.ogg");
 
-    this.getSprite().SetEmitSound("WraithFly.ogg");
-    this.getSprite().SetEmitSoundPaused(false);
+	this.getSprite().SetEmitSound("WraithFly.ogg");
+	this.getSprite().SetEmitSoundPaused(false);
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 	
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	this.Tag("zombie");
 	this.Tag("enemy");
 	this.Tag("wraiths");
@@ -57,7 +53,7 @@ void onTick(CBlob@ this)
 			this.Tag("exploding");
 		    this.set_s32("explosion_timer", getGameTime() + TIME_TO_EXPLODE);
 
-            this.getSprite().PlaySound("/WraithDie");
+	this.getSprite().PlaySound("/WraithDie");
 		}
 
 		if (getNet().isServer())
@@ -66,15 +62,15 @@ void onTick(CBlob@ this)
        	 	if (timer <= 0)
         	{
             	// boom
-                this.server_SetHealth(-1.0f);
-                this.server_Die();
+	this.server_SetHealth(-1.0f);
+	this.server_Die();
             }
 		}
 		else
 		{
-            this.SetLight( true );
-            this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
-            this.SetLightColor( SColor(255, 211, 121, 224) );
+	this.SetLight( true );
+	this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
+	this.SetLightColor( SColor(255, 211, 121, 224) );
 
             if (XORRandom(128) == 0)
             {

--- a/Entities/Zombies/Writher/Writher.as
+++ b/Entities/Zombies/Writher/Writher.as
@@ -9,51 +9,29 @@ const int COINS_ON_DEATH = 25;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("survivorplayer", 0.8f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("ruinstorch", 0.9f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("pet", 0.9f, true);
-		infos.push_back(i);
-	}	
-	{
-		TargetInfo i("lantern", 0.9f);
-		infos.push_back(i);		
-	}
-	{
-		TargetInfo i("stone_door", 1.0f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("wooden_door", 0.9f);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("survivorbuilding", 0.6f, true);
-		infos.push_back(i);
-	}		
+	addTargetInfo(infos, "survivorplayer", 0.8f, true, true);
+	addTargetInfo(infos, "ruinstorch", 0.9f, true);
+	addTargetInfo(infos, "pet", 0.9f, true);
+	addTargetInfo(infos, "lantern", 0.9f);
+	addTargetInfo(infos, "stone_door", 1.0f);
+	addTargetInfo(infos, "wooden_door", 0.9f);
+	addTargetInfo(infos, "survivorbuilding", 0.6f, true);
 
 	this.set("target infos", infos);
 
 	this.set_u16("coins on death", COINS_ON_DEATH);
 	this.set_f32(target_searchrad_property, 512.0f);
 
-    this.getSprite().PlaySound("WraithSpawn.ogg");
+	this.getSprite().PlaySound("WraithSpawn.ogg");
 
-    this.getSprite().SetEmitSound("WraithFly.ogg");
-    this.getSprite().SetEmitSoundPaused(false);
+	this.getSprite().SetEmitSound("WraithFly.ogg");
+	this.getSprite().SetEmitSoundPaused(false);
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 	
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	this.Tag("zombie");
 	this.Tag("enemy");
 	this.Tag("wraiths");
@@ -81,7 +59,7 @@ void onTick(CBlob@ this)
 			this.Tag("exploding");
 		    this.set_s32("explosion_timer", getGameTime() + TIME_TO_EXPLODE);
 
-            this.getSprite().PlaySound("/WraithDie");
+	this.getSprite().PlaySound("/WraithDie");
 		}
 
 		if (getNet().isServer())
@@ -90,15 +68,15 @@ void onTick(CBlob@ this)
        	 	if (timer <= 0)
         	{
             	// boom
-                this.server_SetHealth(-1.0f);
-                this.server_Die();
+	this.server_SetHealth(-1.0f);
+	this.server_Die();
             }
 		}
 		else
 		{
-            this.SetLight( true );
-            this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
-            this.SetLightColor( SColor(255, 211, 121, 224) );
+	this.SetLight( true );
+	this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
+	this.SetLightColor( SColor(255, 211, 121, 224) );
 
             if (XORRandom(128) == 0)
             {

--- a/Entities/Zombies/pBanshee/pBanshee.as
+++ b/Entities/Zombies/pBanshee/pBanshee.as
@@ -11,27 +11,23 @@ const int COINS_ON_DEATH = 50;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
-
-	{
-		TargetInfo i("survivorplayer", 1.0f, true, true);
-		infos.push_back(i);	
-	}
+	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
 
 	this.set("target infos", infos);
 
 	this.set_u16("coins on death", COINS_ON_DEATH);
 	this.set_f32(target_searchrad_property, 512.0f);
 
-    this.getSprite().PlaySound("BansheeSpawn.ogg");
+	this.getSprite().PlaySound("BansheeSpawn.ogg");
 
-    this.getSprite().SetEmitSound("BansheeFly.ogg");
-    this.getSprite().SetEmitSoundPaused(false);
+	this.getSprite().SetEmitSound("BansheeFly.ogg");
+	this.getSprite().SetEmitSoundPaused(false);
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	this.Tag("zombie");
 	this.Tag("enemy");
 
@@ -67,15 +63,15 @@ void onTick(CBlob@ this)
        	 	if (timer <= 0)
         	{
             	// boom
-                this.server_SetHealth(-1.0f);
-                this.server_Die();
+	this.server_SetHealth(-1.0f);
+	this.server_Die();
             }
 		}
 		else
 		{
-            this.SetLight( true );
-            this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
-            this.SetLightColor( SColor(255, 211, 121, 224) );
+	this.SetLight( true );
+	this.SetLightRadius(this.get_f32("explosive_radius") * 0.5f);
+	this.SetLightColor( SColor(255, 211, 121, 224) );
 
             if (XORRandom(128) == 0)
             {

--- a/Entities/Zombies/pGreg/pGreg.as
+++ b/Entities/Zombies/pGreg/pGreg.as
@@ -7,31 +7,24 @@ const int COINS_ON_DEATH = 25;
 void onInit(CBlob@ this)
 {
 	TargetInfo[] infos;
+	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+	addTargetInfo(infos, "mage", 0.6f);
 
-	{
-		TargetInfo i("survivorplayer", 1.0f, true, true);
-		infos.push_back(i);
-	}
-	{
-		TargetInfo i("mage", 0.6f);
-		infos.push_back(i);
-	}	
-	
 	this.set("target infos", @infos);
 
 	this.set_u16("coins on death", COINS_ON_DEATH);
 	this.set_f32(target_searchrad_property, 512.0f);
 
-    this.getSprite().SetEmitSound("Wings.ogg");
-    this.getSprite().SetEmitSoundPaused(false);
+	this.getSprite().SetEmitSound("Wings.ogg");
+	this.getSprite().SetEmitSoundPaused(false);
 
-    this.getSprite().PlayRandomSound("/GargCry");
+	this.getSprite().PlayRandomSound("/GargCry");
 	this.getShape().SetRotationsAllowed(false);
 
 	this.getBrain().server_SetActive(true);
 
 	this.set_f32("gib health", 0.0f);
-    this.Tag("flesh");
+	this.Tag("flesh");
 	this.Tag("zombie");
 	this.Tag("enemy");
 	
@@ -73,5 +66,5 @@ f32 onHit( CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hit
 
 void onDie( CBlob@ this )
 {
-    this.getSprite().PlaySound("/GargRoar");	
+	this.getSprite().PlaySound("/GargRoar");	
 }


### PR DESCRIPTION
## Summary
- add helper to append TargetInfo records
- replace verbose TargetInfo initialization blocks with concise calls across zombies and NPC scripts
- standardize indentation in updated scripts

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a3872e155c83339273edbc5e4f17c4