### PR TITLE
Spawn zombies at portals and ruins

### DIFF
--- a/Entities/Landmarks/ZombieRuins/ZombieRuins.cfg
+++ b/Entities/Landmarks/ZombieRuins/ZombieRuins.cfg
@@ -69,7 +69,7 @@ $inventory_factory                         =
 
 # general
 
-$name                                      = zombie_ruins
+$name                                      = zombieruins
 @$scripts                                  = SpecialNoBuild.as;
                                               ZombieRuins.as;
                                               AlignToTiles.as;

--- a/Scripts/MapLoaders/BasePNGLoader.as
+++ b/Scripts/MapLoaders/BasePNGLoader.as
@@ -31,7 +31,7 @@ const SColor color_base(0xff2ddbe8);
 const SColor color_cloud(0xff52b9c7);
 const SColor color_torch(0xffe39f20);
 const SColor color_zombie_spawn(0xff05ff05);
-const SColor color_zombie_ruins(0xff329332);
+const SColor color_zombieruins(0xff329332);
 const SColor color_zombie_portal(0xff710d71);
 const SColor color_zombie_statue(255, 61, 16, 123);
 const SColor color_grave(0xffe900f0);
@@ -271,14 +271,12 @@ class PNGLoader
 			spawnBlob( map, "ruinstorch", offset, 0);
 			offsets[autotile_offset].push_back( offset );
 		}	
-		else if (pixel == color_zombie_spawn) {
-			spawnBlob( map, "zombieportal", offset, 1);
-			AddMarker( map, offset, "zombie spawn" );
-		}			
-		else if (pixel == color_zombie_ruins) {
-			spawnBlob( map, "zombie_ruins", offset, 1);
-			AddMarker( map, offset, "zombie spawn" );
-		}	
+                else if (pixel == color_zombie_spawn) {
+                        spawnBlob( map, "zombieportal", offset, 1);
+                }
+                else if (pixel == color_zombieruins) {
+                        spawnBlob( map, "zombieruins", offset, 1);
+                }
 		else if (pixel == color_zombie_portal) {
 			AddMarker( map, offset, "zombie alter" );
 		}		


### PR DESCRIPTION
## Summary
- Spawn zombies at existing `zombieportal` blobs rather than map markers
- After `ruined_portal_day`, also spawn from `zombieruins` and keep the ruins intact
- Rename `zombie_ruins` blob to `zombieruins` and drop marker usage in map loader

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a3cef1282c8333ad9ebae97351d748