### PR TITLE
Enable ruin portals after first pillar falls

### DIFF
--- a/Entities/Landmarks/RuinsTorch/RuinsTorchLogic.as
+++ b/Entities/Landmarks/RuinsTorch/RuinsTorchLogic.as
@@ -231,6 +231,14 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 void onDie(CBlob@ this)
 {
-	getRules().set_bool("everyones_dead", true);
-	Render::RemoveScript(this.get_u16("renderID"));
+        CRules@ rules = getRules();
+        rules.set_bool("everyones_dead", true);
+
+        if (!rules.get_bool("ruins_portal_active"))
+        {
+                rules.set_bool("ruins_portal_active", true);
+                rules.Sync("ruins_portal_active", true);
+        }
+
+        Render::RemoveScript(this.get_u16("renderID"));
 }

--- a/Rules/Scripts/Zombies/Zombies_Config.as
+++ b/Rules/Scripts/Zombies/Zombies_Config.as
@@ -30,7 +30,8 @@ void Config(ZombiesCore@ this)
 	this.rules.set_s32("days_to_survive", 0);   // <= 0 means endless
     this.rules.set_s32("curse_day",        250);  // night(s) from which survivors can auto-zombify
     this.rules.set_s32("hardmode_day",     100);  // the day zombies can spawn during the day
-    this.rules.set_s32("ruined_portal_day", 150); // day that ruins convert to portals
+    this.rules.set_bool("ruins_portal_active", false); // ruins become portals once a pillar falls
+    this.rules.Sync("ruins_portal_active", true);
 
 	// ----------------------------
 	// Flavor toggles

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -67,7 +67,7 @@ class ZombiesCore : RulesCore
         const int hardmode_day      = rules.get_s32("hardmode_day");
         const int curse_day         = rules.get_s32("curse_day");
         const int days_offset       = rules.get_s32("days_offset");
-        const int ruined_portal_day = rules.get_s32("ruined_portal_day");
+        const bool ruins_portal_active = rules.get_bool("ruins_portal_active");
         const int dayNumber         = days_offset + ((getGameTime() - gamestart) / getTicksASecond() / day_cycle) + 1;
 
 		const int timeElapsed  = getGameTime() - gamestart;
@@ -216,7 +216,7 @@ class ZombiesCore : RulesCore
                     zombiePlaces.push_back(portals[i].getPosition());
                 }
 
-                if (dayNumber >= ruined_portal_day)
+                if (ruins_portal_active)
                 {
                     CBlob@[] ruins;
                     getBlobsByName("zombieruins", @ruins);

--- a/Rules/Scripts/Zombies/Zombies_Interface.as
+++ b/Rules/Scripts/Zombies/Zombies_Interface.as
@@ -169,11 +169,10 @@ void DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
 	const float titleH   = 20.0f;   // approximate title height without measuring
 	const float titleGap = 6.0f;
 
-	// compute basics
+        // compute basics
         const int days_offset = rules.get_s32("days_offset");
         const int hardmode_day       = rules.get_s32("hardmode_day");
         const int curse_day          = rules.get_s32("curse_day");
-        const int ruined_portal_day  = rules.get_s32("ruined_portal_day");
         const int ignore_light       = (hardmode_day - (days_offset));
 
 	// counters
@@ -198,10 +197,9 @@ void DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
         lines.insertLast("Undead: " + num_undead);
 	lines.insertLast("Difficulty: " + diff_str);
 	lines.insertLast("Zombies: " + (num_zombies + num_pzombies) + "/" + max_zombies);
-	lines.insertLast("Hard Starts: " + (hardmode_day - ((days_offset/14)*10)));
+        lines.insertLast("Hard Starts: " + (hardmode_day - ((days_offset/14)*10)));
         lines.insertLast("Curse Starts: " + curse_day);
-        lines.insertLast("Ruined Portals: " + ruined_portal_day);
-	lines.insertLast("Altars Remaining: " + num_zombiePortals);
+        lines.insertLast("Altars Remaining: " + num_zombiePortals);
 
 	// fixed width panel (tweak to taste)
 	const float boxW = 260.0f;


### PR DESCRIPTION
## Summary
- Remove day-based ruined portal activation
- Activate ruined portals when the first ruinstorch is destroyed
- Allow zombies to spawn from ruins once portals awaken

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a3d7a5fb4083338926a02cd7d12fcf