### PR TITLE
Revamp HUD record display with kill tracking

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Interface.as
+++ b/Rules/Scripts/Zombies/Zombies_Interface.as
@@ -29,8 +29,9 @@ void onRender(CRules@ this)
 		return; // popup already shown above
 	}
 
-        const float offset = DrawRecordStatus(this);
-        DrawZombiesHUDTopRight(this, offset);
+        float offset = DrawRecordStatus(this);
+        offset = DrawZombiesHUDTopRight(this, offset);
+        offset = DrawStartStatus(this, offset);
         DrawRevivalTimer(this, lp);
 }
 
@@ -76,47 +77,48 @@ float DrawRecordStatus(CRules@ rules)
         const string title = "RECORD STATUS";
 
         // pull data
-        const int days          = rules.get_s32("hud_dayNumber");
-        const u16 mapRecord     = rules.get_u16("map_record");
-        const bool beatMap      = days > mapRecord;
-        const u16 globalRecord  = rules.get_u16("global_record");
-        const bool beatGlobal   = days > globalRecord;
-        const bool cheated      = rules.get_bool("dayCheated");
-        const u32 undeadKills   = rules.get_u32("undead_kills");
+        const int days            = rules.get_s32("hud_dayNumber");
+        const u16 mapRecord       = rules.get_u16("map_record");
+        const u16 globalRecord    = rules.get_u16("global_record");
+        const u32 undeadKills     = rules.get_u32("undead_kills");
+        const u32 mapKillRecord   = rules.get_u32("map_kill_record");
+        const u32 globalKillRecord= rules.get_u32("global_kill_record");
+        const bool cheated        = rules.get_bool("dayCheated");
 
-        SColor goodColor   = SColor(255, 0, 255, 0);
-        SColor normalColor = SColor(255, 255, 255, 255);
+        const bool beatMap        = days > mapRecord;
+        const bool beatGlobal     = days > globalRecord;
+        const bool beatMapKills   = undeadKills > mapKillRecord;
+        const bool beatGlobalKills= undeadKills > globalKillRecord;
+
+        // colors
+        SColor goodColor         = SColor(255, 0, 255, 0);
+        SColor dayColor          = SColor(255, 255, 255, 0);      // yellow
+        SColor mapRecordColor    = SColor(255, 255, 165, 0);      // orange
+        SColor globalRecordColor = SColor(255, 180, 0, 255);      // purple
+        SColor killColor         = SColor(255, 255, 0, 0);        // red
+        SColor mapKillColor      = SColor(255, 255, 100, 100);    // light red
+        SColor globalKillColor   = SColor(255, 255, 0, 200);      // pink
 
         array<string> lines;
         array<SColor> cols;
 
         lines.insertLast("Days Survived: " + days);
-        cols.push_back(normalColor);
+        cols.push_back(dayColor);
+
+        lines.insertLast("Map Record: " + mapRecord);
+        cols.push_back(beatMap ? goodColor : mapRecordColor);
+
+        lines.insertLast("Global Record: " + globalRecord);
+        cols.push_back(beatGlobal ? goodColor : globalRecordColor);
 
         lines.insertLast("Undead Killed: " + undeadKills);
-        cols.push_back(normalColor);
+        cols.push_back(killColor);
 
-        if (beatMap)
-        {
-                lines.insertLast("Map Record Beat!");
-                cols.push_back(goodColor);
-        }
-        else
-        {
-                lines.insertLast("Map Record: " + mapRecord);
-                cols.push_back(normalColor);
-        }
+        lines.insertLast("Map Kill Record: " + mapKillRecord);
+        cols.push_back(beatMapKills ? goodColor : mapKillColor);
 
-        if (beatGlobal)
-        {
-                lines.insertLast("Global Record Beat!");
-                cols.push_back(goodColor);
-        }
-        else
-        {
-                lines.insertLast("Global Record: " + globalRecord);
-                cols.push_back(normalColor);
-        }
+        lines.insertLast("Global Kill Record: " + globalKillRecord);
+        cols.push_back(beatGlobalKills ? goodColor : globalKillColor);
 
         if (cheated)
         {
@@ -155,7 +157,7 @@ float DrawRecordStatus(CRules@ rules)
 // HUD: Top-right status panel
 // ------------------------------
 // existing round status panel (can be offset vertically)
-void DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
+float DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
 {
         if (g_videorecording) return;
 
@@ -169,11 +171,7 @@ void DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
 	const float titleH   = 20.0f;   // approximate title height without measuring
 	const float titleGap = 6.0f;
 
-        // compute basics
-        const int days_offset = rules.get_s32("days_offset");
-        const int hardmode_day       = rules.get_s32("hardmode_day");
-        const int curse_day          = rules.get_s32("curse_day");
-        const int ignore_light       = (hardmode_day - (days_offset));
+        // compute basics (no additional values needed currently)
 
 	// counters
 	const int num_zombies       = rules.get_s32("num_zombies");
@@ -196,9 +194,7 @@ void DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
         lines.insertLast("Survivors: " + num_survivors_p);
         lines.insertLast("Undead: " + num_undead);
 	lines.insertLast("Difficulty: " + diff_str);
-	lines.insertLast("Zombies: " + (num_zombies + num_pzombies) + "/" + max_zombies);
-        lines.insertLast("Hard Starts: " + (hardmode_day - ((days_offset/14)*10)));
-        lines.insertLast("Curse Starts: " + curse_day);
+        lines.insertLast("Zombies: " + (num_zombies + num_pzombies) + "/" + max_zombies);
         lines.insertLast("Altars Remaining: " + num_zombiePortals);
 
 	// fixed width panel (tweak to taste)
@@ -212,10 +208,10 @@ void DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
 
 	// background + thin border
 	GUI::DrawRectangle(tl, br, SColor(140, 0, 0, 0));
-	GUI::DrawRectangle(tl, Vec2f(br.x, tl.y + 1), SColor(80, 255, 255, 255));
-	GUI::DrawRectangle(Vec2f(tl.x, br.y - 1), br, SColor(80, 255, 255, 255));
-	GUI::DrawRectangle(tl, Vec2f(tl.x + 1, br.y), SColor(80, 255, 255, 255));
-	GUI::DrawRectangle(Vec2f(br.x - 1, tl.y), br, SColor(80, 255, 255, 255));
+        GUI::DrawRectangle(tl, Vec2f(br.x, tl.y + 1), SColor(80, 255, 255, 255));
+        GUI::DrawRectangle(Vec2f(tl.x, br.y - 1), br, SColor(80, 255, 255, 255));
+        GUI::DrawRectangle(tl, Vec2f(tl.x + 1, br.y), SColor(80, 255, 255, 255));
+        GUI::DrawRectangle(Vec2f(br.x - 1, tl.y), br, SColor(80, 255, 255, 255));
 
 	// draw (left-aligned inside panel)
 	Vec2f cursor = Vec2f(tl.x + padX, tl.y + padY);
@@ -223,24 +219,87 @@ void DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
 	GUI::DrawText(title, cursor, SColor(255, 255, 220, 90));
 	cursor.y += titleH + titleGap;
 
-	for (uint i = 0; i < lines.length(); i++)
-	{
-		SColor col = SColor(255, 230, 230, 230);
+        for (uint i = 0; i < lines.length(); i++)
+        {
+                SColor col = SColor(255, 230, 230, 230);
 
-		if (lines[i].findFirst("Zombies: ") == 0)
-			col = SColor(255, 255, 165, 0);        // Orange
-		else if (lines[i].findFirst("Survivors: ") == 0)
-			col = SColor(255, 0, 120, 255);        // Blue
-		else if (lines[i].findFirst("Undead: ") == 0)
-			col = SColor(255, 255, 0, 0);          // Red
-		else if (lines[i].findFirst("Difficulty: ") == 0)
-			col = SColor(255, 255, 255, 0);        // Yellow
-		else if (lines[i].findFirst("Pillars: ") == 0)
-			col = SColor(255, 100, 200, 255);      // Light Blue
+                if (lines[i].findFirst("Zombies: ") == 0)
+                        col = SColor(255, 255, 165, 0);        // Orange
+                else if (lines[i].findFirst("Survivors: ") == 0)
+                        col = SColor(255, 0, 120, 255);        // Blue
+                else if (lines[i].findFirst("Undead: ") == 0)
+                        col = SColor(255, 255, 0, 0);          // Red
+                else if (lines[i].findFirst("Difficulty: ") == 0)
+                        col = SColor(255, 255, 255, 0);        // Yellow
+                else if (lines[i].findFirst("Pillars: ") == 0)
+                        col = SColor(255, 100, 200, 255);      // Light Blue
+                else if (lines[i].findFirst("Altars Remaining: ") == 0)
+                        col = SColor(255, 160, 0, 255);        // Purple
 
-		GUI::DrawText(lines[i], cursor, col);
-		cursor.y += lineH;
-	}
+                GUI::DrawText(lines[i], cursor, col);
+                cursor.y += lineH;
+        }
+
+        return boxH + margin + topOffset;
+}
+
+// ------------------------------
+// HUD: Hard/Curse start counters
+// ------------------------------
+float DrawStartStatus(CRules@ rules, const float topOffset = 0.0f)
+{
+        if (g_videorecording) return 0.0f;
+
+        GUI::SetFont("menu");
+
+        const float margin   = 24.0f;
+        const float padX     = 10.0f;
+        const float padY     = 8.0f;
+        const float lineH    = 18.0f;
+        const float titleH   = 20.0f;
+        const float titleGap = 6.0f;
+
+        const string title = "START STATUS";
+
+        // pull data
+        const int days_offset = rules.get_s32("days_offset");
+        const int hardmode_day = rules.get_s32("hardmode_day");
+        const int curse_day   = rules.get_s32("curse_day");
+
+        array<string> lines;
+        lines.insertLast("Hard Starts: " + (hardmode_day - ((days_offset/14)*10)));
+        lines.insertLast("Curse Starts: " + curse_day);
+
+        const float boxW = 260.0f;
+        const float boxH = padY*2.0f + titleH + titleGap + (lines.length() * lineH);
+
+        Vec2f screen = getDriver().getScreenDimensions();
+        Vec2f br(screen.x - margin, margin + boxH + topOffset);
+        Vec2f tl(br.x - boxW, br.y - boxH);
+
+        GUI::DrawRectangle(tl, br, SColor(140, 0, 0, 0));
+        GUI::DrawRectangle(tl, Vec2f(br.x, tl.y + 1), SColor(80, 255, 255, 255));
+        GUI::DrawRectangle(Vec2f(tl.x, br.y - 1), br, SColor(80, 255, 255, 255));
+        GUI::DrawRectangle(tl, Vec2f(tl.x + 1, br.y), SColor(80, 255, 255, 255));
+        GUI::DrawRectangle(Vec2f(br.x - 1, tl.y), br, SColor(80, 255, 255, 255));
+
+        Vec2f cursor = Vec2f(tl.x + padX, tl.y + padY);
+        GUI::DrawText(title, cursor, SColor(255, 255, 220, 90));
+        cursor.y += titleH + titleGap;
+
+        for (uint i = 0; i < lines.length(); i++)
+        {
+                SColor col = SColor(255, 230, 230, 230);
+                if (lines[i].findFirst("Hard Starts: ") == 0)
+                        col = SColor(255, 255, 165, 0);        // Orange
+                else if (lines[i].findFirst("Curse Starts: ") == 0)
+                        col = SColor(255, 160, 0, 255);        // Purple
+
+                GUI::DrawText(lines[i], cursor, col);
+                cursor.y += lineH;
+        }
+
+        return boxH + margin + topOffset;
 }
 
 // small helper for live player count by team

--- a/Rules/Scripts/Zombies/Zombies_Records.as
+++ b/Rules/Scripts/Zombies/Zombies_Records.as
@@ -31,6 +31,12 @@ void LoadRecords(CRules@ this)
     string map = this.get_string("map_name");
     this.set_u16("map_record", cfg.exists("map_" + map) ? cfg.read_u16("map_" + map) : 0);
     this.set_u16("global_record", cfg.exists("global") ? cfg.read_u16("global") : 0);
+    this.set_u32("map_kill_record", cfg.exists("map_kills_" + map) ? cfg.read_u32("map_kills_" + map) : 0);
+    this.set_u32("global_kill_record", cfg.exists("global_kills") ? cfg.read_u32("global_kills") : 0);
+    this.Sync("map_record", true);
+    this.Sync("global_record", true);
+    this.Sync("map_kill_record", true);
+    this.Sync("global_kill_record", true);
 }
 
 void SaveRecords(CRules@ this)
@@ -40,6 +46,8 @@ void SaveRecords(CRules@ this)
     string map = this.get_string("map_name");
     cfg.add_u16("map_" + map, this.get_u16("map_record"));
     cfg.add_u16("global", this.get_u16("global_record"));
+    cfg.add_u32("map_kills_" + map, this.get_u32("map_kill_record"));
+    cfg.add_u32("global_kills", this.get_u32("global_kill_record"));
     cfg.saveFile(records_file);
 }
 
@@ -51,15 +59,28 @@ void onTick(CRules@ this)
     {
         this.set_bool("records_saved", true);
         const u16 days = getDaysSurvived(this);
+        const u32 kills = this.get_u32("undead_kills");
         if (!this.get_bool("dayCheated"))
         {
             u16 mapRec = this.get_u16("map_record");
             u16 globRec = this.get_u16("global_record");
+            u32 mapKillRec = this.get_u32("map_kill_record");
+            u32 globKillRec = this.get_u32("global_kill_record");
+
             if (days > mapRec)
                 this.set_u16("map_record", days);
             if (days > globRec)
                 this.set_u16("global_record", days);
+            if (kills > mapKillRec)
+                this.set_u32("map_kill_record", kills);
+            if (kills > globKillRec)
+                this.set_u32("global_kill_record", kills);
+
             SaveRecords(this);
+            this.Sync("map_record", true);
+            this.Sync("global_record", true);
+            this.Sync("map_kill_record", true);
+            this.Sync("global_kill_record", true);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Highlight days survived in yellow and show map/global records for days and kills with vibrant colors
- Track and persist map/global undead kill records alongside day records
- Split hard and curse start counters into their own "START STATUS" HUD panel

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a3e2766ac88333a6e6fb3ffe0aeb10