### PR TITLE
Improve zombie target priorities and digging

### DIFF
--- a/Entities/Zombies/Greg/Greg.as
+++ b/Entities/Zombies/Greg/Greg.as
@@ -6,9 +6,13 @@ const int COINS_ON_DEATH = 25;
 
 void onInit(CBlob@ this)
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
-	addTargetInfo(infos, "mage", 0.9f);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        addTargetInfo(infos, "mage", 0.9f);
 
 	this.set("target infos", @infos);
 

--- a/Entities/Zombies/Greg/Greg2.as
+++ b/Entities/Zombies/Greg/Greg2.as
@@ -6,9 +6,13 @@ const int COINS_ON_DEATH = 25;
 
 void onInit(CBlob@ this)
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
-	addTargetInfo(infos, "mage", 0.9f);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        addTargetInfo(infos, "mage", 0.9f);
 
 	this.set("target infos", @infos);
 

--- a/Entities/Zombies/Immolator/Immolator.as
+++ b/Entities/Zombies/Immolator/Immolator.as
@@ -8,13 +8,14 @@ const int COINS_ON_DEATH = 10;
 
 void onInit(CBlob@ this)
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
-	addTargetInfo(infos, "pet", 0.9f, true);
-	addTargetInfo(infos, "lantern", 0.9f);
-	addTargetInfo(infos, "stone_door", 0.6f);
-	addTargetInfo(infos, "wooden_door", 0.6f);
-	addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        addTargetInfo(infos, "pet", 0.9f, true);
+        addTargetInfo(infos, "lantern", 0.9f);
 
 	this.set("target infos", infos);
 

--- a/Entities/Zombies/Scripts/TagAsLargeZombie.as
+++ b/Entities/Zombies/Scripts/TagAsLargeZombie.as
@@ -2,29 +2,34 @@
 
 void onInit( CBlob@ this )
 {
-	this.Tag("zombie");
-	this.Tag("enemy");
-	this.Tag("large_zombie");
-	SetupTargets(this);
+        this.Tag("zombie");
+        this.Tag("enemy");
+        this.Tag("large_zombie");
+        SetupTargets(this);
+        if (!this.hasScript("ZombieDigCont.as"))
+        {
+                this.AddScript("ZombieDigCont.as");
+        }
 }
 
 void SetupTargets( CBlob@ this )
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
-	addTargetInfo(infos, "migrantbot", 1.0f, true);
-	addTargetInfo(infos, "ally", 0.9f, true);
-	addTargetInfo(infos, "survivormechanism", 0.9f);
-	addTargetInfo(infos, "survivorbuilding", 0.8f, true);
-	addTargetInfo(infos, "stone_door", 0.6f);
-	addTargetInfo(infos, "mounted_bow", 0.4f);
-	addTargetInfo(infos, "mounted_bazooka", 0.4f);
-	addTargetInfo(infos, "wooden_door", 0.4f);
-	addTargetInfo(infos, "wooden_platform", 0.4f);
-	addTargetInfo(infos, "pet", 0.2f, true);
-	addTargetInfo(infos, "lantern", 0.2f);
-	addTargetInfo(infos, "medium_zombie", 0.2f);
-	addTargetInfo(infos, "lesser_zombie", 0.2f);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        addTargetInfo(infos, "migrantbot", 1.0f, true);
+        addTargetInfo(infos, "ally", 0.9f, true);
+        addTargetInfo(infos, "survivormechanism", 0.9f);
+        addTargetInfo(infos, "mounted_bow", 0.4f);
+        addTargetInfo(infos, "mounted_bazooka", 0.4f);
+        addTargetInfo(infos, "wooden_platform", 0.4f);
+        addTargetInfo(infos, "pet", 0.2f, true);
+        addTargetInfo(infos, "lantern", 0.2f);
+        addTargetInfo(infos, "medium_zombie", 0.2f);
+        addTargetInfo(infos, "lesser_zombie", 0.2f);
 
 	this.set("target infos", infos);
 

--- a/Entities/Zombies/Scripts/TagAsLesserZombie.as
+++ b/Entities/Zombies/Scripts/TagAsLesserZombie.as
@@ -2,25 +2,31 @@
 
 void onInit( CBlob@ this )
 {
-	this.Tag("zombie");
-	this.Tag("enemy");
-	this.Tag("lesser_zombie");
-	SetupTargets(this);
+        this.Tag("zombie");
+        this.Tag("enemy");
+        this.Tag("lesser_zombie");
+        SetupTargets(this);
+        if (!this.hasScript("ZombieDigCont.as"))
+        {
+                this.AddScript("ZombieDigCont.as");
+        }
 }
 
 void SetupTargets( CBlob@ this )
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
-	addTargetInfo(infos, "migrantbot", 1.0f, true);
-	addTargetInfo(infos, "ally", 0.9f, true);
-	addTargetInfo(infos, "survivorbuilding", 0.8f, true);
-	addTargetInfo(infos, "mounted_bow", 0.4f);
-	addTargetInfo(infos, "mounted_bazooka", 0.4f);
-	addTargetInfo(infos, "wooden_door", 0.4f);
-	addTargetInfo(infos, "wooden_platform", 0.4f);
-	addTargetInfo(infos, "pet", 0.2f, true);
-	addTargetInfo(infos, "lantern", 0.2f);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        addTargetInfo(infos, "migrantbot", 1.0f, true);
+        addTargetInfo(infos, "ally", 0.9f, true);
+        addTargetInfo(infos, "mounted_bow", 0.4f);
+        addTargetInfo(infos, "mounted_bazooka", 0.4f);
+        addTargetInfo(infos, "wooden_platform", 0.4f);
+        addTargetInfo(infos, "pet", 0.2f, true);
+        addTargetInfo(infos, "lantern", 0.2f);
 
 	this.set("target infos", infos);
 

--- a/Entities/Zombies/Scripts/TagAsMediumZombie.as
+++ b/Entities/Zombies/Scripts/TagAsMediumZombie.as
@@ -2,26 +2,32 @@
 
 void onInit( CBlob@ this )
 {
-	this.Tag("zombie");
-	this.Tag("enemy");
-	this.Tag("medium_zombie");
-	SetupTargets(this);
+        this.Tag("zombie");
+        this.Tag("enemy");
+        this.Tag("medium_zombie");
+        SetupTargets(this);
+        if (!this.hasScript("ZombieDigCont.as"))
+        {
+                this.AddScript("ZombieDigCont.as");
+        }
 }
 
 void SetupTargets( CBlob@ this )
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
-	addTargetInfo(infos, "migrantbot", 1.0f, true);
-	addTargetInfo(infos, "ally", 0.9f, true);
-	addTargetInfo(infos, "survivorbuilding", 0.8f, true);
-	addTargetInfo(infos, "mounted_bow", 0.4f);
-	addTargetInfo(infos, "mounted_bazooka", 0.4f);
-	addTargetInfo(infos, "wooden_door", 0.4f);
-	addTargetInfo(infos, "wooden_platform", 0.4f);
-	addTargetInfo(infos, "pet", 0.2f, true);
-	addTargetInfo(infos, "lantern", 0.2f);
-	addTargetInfo(infos, "lesser_zombie", 0.2f);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        addTargetInfo(infos, "migrantbot", 1.0f, true);
+        addTargetInfo(infos, "ally", 0.9f, true);
+        addTargetInfo(infos, "mounted_bow", 0.4f);
+        addTargetInfo(infos, "mounted_bazooka", 0.4f);
+        addTargetInfo(infos, "wooden_platform", 0.4f);
+        addTargetInfo(infos, "pet", 0.2f, true);
+        addTargetInfo(infos, "lantern", 0.2f);
+        addTargetInfo(infos, "lesser_zombie", 0.2f);
 
 	this.set("target infos", infos);
 

--- a/Entities/Zombies/Scripts/TagAsNecromancerZombie.as
+++ b/Entities/Zombies/Scripts/TagAsNecromancerZombie.as
@@ -2,26 +2,31 @@
 
 void onInit( CBlob@ this )
 {
-	this.Tag("zombie");
-	this.Tag("enemy");
-	this.Tag("necromancer_zombie");
-	SetupTargets(this);
+        this.Tag("zombie");
+        this.Tag("enemy");
+        this.Tag("necromancer_zombie");
+        SetupTargets(this);
+        if (!this.hasScript("ZombieDigCont.as"))
+        {
+                this.AddScript("ZombieDigCont.as");
+        }
 }
 
 void SetupTargets( CBlob@ this )
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
-	addTargetInfo(infos, "migrantbot", 1.0f, true);
-	addTargetInfo(infos, "ally", 0.9f, true);
-	addTargetInfo(infos, "survivorbuilding", 0.8f, true);
-	addTargetInfo(infos, "stone_door", 0.6f);
-	addTargetInfo(infos, "mounted_bow", 0.4f);
-	addTargetInfo(infos, "mounted_bazooka", 0.4f);
-	addTargetInfo(infos, "wooden_door", 0.4f);
-	addTargetInfo(infos, "wooden_platform", 0.4f);
-	addTargetInfo(infos, "pet", 0.2f, true);
-	addTargetInfo(infos, "lantern", 0.2f);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        addTargetInfo(infos, "migrantbot", 1.0f, true);
+        addTargetInfo(infos, "ally", 0.9f, true);
+        addTargetInfo(infos, "mounted_bow", 0.4f);
+        addTargetInfo(infos, "mounted_bazooka", 0.4f);
+        addTargetInfo(infos, "wooden_platform", 0.4f);
+        addTargetInfo(infos, "pet", 0.2f, true);
+        addTargetInfo(infos, "lantern", 0.2f);
 
 	this.set("target infos", infos);
 

--- a/Entities/Zombies/Wraith/Wraith.as
+++ b/Entities/Zombies/Wraith/Wraith.as
@@ -8,13 +8,14 @@ const int COINS_ON_DEATH = 10;
 
 void onInit(CBlob@ this)
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 0.8f, true, true);
-	addTargetInfo(infos, "pet", 0.9f, true);
-	addTargetInfo(infos, "lantern", 0.9f);
-	addTargetInfo(infos, "stone_door", 1.0f);
-	addTargetInfo(infos, "wooden_door", 0.9f);
-	addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        addTargetInfo(infos, "pet", 0.9f, true);
+        addTargetInfo(infos, "lantern", 0.9f);
 
 	this.set("target infos", infos);
 

--- a/Entities/Zombies/Wraith/Wraith2.as
+++ b/Entities/Zombies/Wraith/Wraith2.as
@@ -8,10 +8,14 @@ const int COINS_ON_DEATH = 0;
 
 void onInit(CBlob@ this)
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 1.0f, true);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
 
-	this.set("target infos", infos);
+        this.set("target infos", infos);
 
 	this.set_u16("coins on death", COINS_ON_DEATH);
 	this.set_f32(target_searchrad_property, 512.0f);

--- a/Entities/Zombies/Writher/Writher.as
+++ b/Entities/Zombies/Writher/Writher.as
@@ -8,14 +8,14 @@ const int COINS_ON_DEATH = 25;
 
 void onInit(CBlob@ this)
 {
-	TargetInfo[] infos;
-	addTargetInfo(infos, "survivorplayer", 0.8f, true, true);
-	addTargetInfo(infos, "ruinstorch", 0.9f, true);
-	addTargetInfo(infos, "pet", 0.9f, true);
-	addTargetInfo(infos, "lantern", 0.9f);
-	addTargetInfo(infos, "stone_door", 1.0f);
-	addTargetInfo(infos, "wooden_door", 0.9f);
-	addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        TargetInfo[] infos;
+        addTargetInfo(infos, "survivorplayer", 1.0f, true, true);
+        addTargetInfo(infos, "ruinstorch", 1.0f, true, true);
+        addTargetInfo(infos, "stone_door", 0.9f);
+        addTargetInfo(infos, "wooden_door", 0.9f);
+        addTargetInfo(infos, "survivorbuilding", 0.6f, true);
+        addTargetInfo(infos, "pet", 0.9f, true);
+        addTargetInfo(infos, "lantern", 0.9f);
 
 	this.set("target infos", infos);
 


### PR DESCRIPTION
## Summary
- Boost zombie focus on players, RuinsTorch, and doors by expanding target info
- Allow all zombie types to dig toward targets by loading `ZombieDigCont` where missing
- Ensure specialized zombies like Wraiths, Writher, Immolator, and Gregs share the same aggressive priorities

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a3ed4ee510833398bf0523fbf9bcca