### PR TITLE
Reset death counters when a new round begins

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Config.as
+++ b/Rules/Scripts/Zombies/Zombies_Config.as
@@ -9,11 +9,16 @@ void Config(ZombiesCore@ this)
 	// Tunables
 	// ============================
 
-	// How long a dead player waits before they can respawn (seconds)
-	this.spawnTime = 60;
+        // How long a dead player waits before they can respawn (seconds)
+        this.spawnTime = 60;
 
-	// ----------------------------
-	// Mob limits (hard caps)
+        // round-specific bookkeeping so values don't persist between rounds
+        this.rules.set_f32("difficulty_bonus", 0.0f);
+        this.rules.set_s32("last_wipe_day", -1);
+        this.rules.set_s32("days_offset", 0);
+
+        // ----------------------------
+        // Mob limits (hard caps)
 	// New waves will not spawn if the active count for that mob is >= its cap
 	// ----------------------------
 	this.rules.set_s32("max_zombies",     250);   // standard zombies

--- a/Rules/Scripts/Zombies/Zombies_Main.as
+++ b/Rules/Scripts/Zombies/Zombies_Main.as
@@ -33,12 +33,26 @@ void Reset(CRules@ this)
 	Vec2f[] gravePlaces; getMap().getMarkers("grave", gravePlaces);
 	for (int i = 0; i < gravePlaces.length; i++) spawnGraves(gravePlaces[i]);
 
-	// all players start as survivors
-	for (u8 i = 0; i < getPlayerCount(); i++)
-	{
-		CPlayer@ p = getPlayer(i);
-		if (p !is null) p.server_setTeamNum(0);
-	}
+        // all players start as survivors with clean stats and spawn instantly
+        for (u8 i = 0; i < getPlayerCount(); i++)
+        {
+                CPlayer@ p = getPlayer(i);
+                if (p !is null)
+                {
+                        p.server_setTeamNum(0);
+                        // wipe round-specific stats so nothing carries over
+                        p.setKills(0);
+                        p.setDeaths(0);
+                        p.setAssists(0);
+                        p.setScore(0);
+                        p.set_u8("killstreak", 0);
+
+                        // clear any leftover respawn timer from the previous round
+                        const string propname = "Zombies spawn time " + p.getUsername();
+                        this.set_u8(propname, 255);
+                        this.SyncToPlayer(propname, p);
+                }
+        }
 
 	this.set("core", @core);
 	this.set("start_gametime", getGameTime() + core.warmUpTime);


### PR DESCRIPTION
## Summary
- Reset each player's deaths on round reset so respawn delay doesn't persist between rounds
- Clear any stored respawn timer to ensure immediate spawn
- Wipe per-player stats like kills, assists, score, and killstreak on reset
- Reset round-tracked config values (difficulty bonus, last wipe day, day offset) for a clean start

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4739008708333a2ffa0f43ff632bc