### PR TITLE
Fix builder mining null pointer

### DIFF
--- a/Entities/Classes/SurvivorBuilder/Builder.cfg
+++ b/Entities/Classes/SurvivorBuilder/Builder.cfg
@@ -223,7 +223,8 @@ $name                                             = builder
 													RunnerActivateable.as;
 													DetectLadder.as; #resets ladder, put before other code that uses ladder
 													SeatHop.as;
-													BuilderLogic.as;
+													BuilderCursorFix.as;
+                                                                                                        BuilderLogic.as;
 													MaterialsFromTiles.as;
 													WoodFromLogs.as;
 													BuilderAutoPickup.as;

--- a/Entities/Classes/SurvivorBuilder/BuilderCursorFix.as
+++ b/Entities/Classes/SurvivorBuilder/BuilderCursorFix.as
@@ -1,0 +1,13 @@
+#include "PlacementCommon.as"
+
+void onInit(CBlob@ this)
+{
+    BlockCursor@ cursor;
+    this.get("blockCursor", @cursor);
+    if (cursor is null)
+    {
+        BlockCursor tempCursor;
+        this.set("blockCursor", @tempCursor);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure Survivor Builder always has a block cursor to prevent mining crashes
- load new initialization script before the main builder logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b0b066a08333bc8e4ef4bf3a18bf