### PR TITLE
Remove server_set time to die from zombies

### DIFF
--- a/Entities/Zombies/Greg/Greg2.as
+++ b/Entities/Zombies/Greg/Greg2.as
@@ -33,9 +33,8 @@ void onInit(CBlob@ this)
 	this.Tag("enemy");
 	this.Tag("gregs");
 	
-	this.getCurrentScript().runFlags |= Script::tick_not_attached;
-	this.getCurrentScript().removeIfTag = "dead";
-	this.server_SetTimeToDie(20);
+        this.getCurrentScript().runFlags |= Script::tick_not_attached;
+        this.getCurrentScript().removeIfTag = "dead";
 }
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point1)

--- a/Entities/Zombies/Skeleton/Skeleton2.as
+++ b/Entities/Zombies/Skeleton/Skeleton2.as
@@ -23,9 +23,8 @@ void onInit(CBlob@ this)
 	this.set_f32("gib health", 0.0f);
     this.Tag("flesh");
 	
-	this.getCurrentScript().runFlags |= Script::tick_not_attached;
-	this.getCurrentScript().removeIfTag = "dead";
-	this.server_SetTimeToDie(20);	
+        this.getCurrentScript().runFlags |= Script::tick_not_attached;
+        this.getCurrentScript().removeIfTag = "dead";
 }
 
 void onTick(CBlob@ this)

--- a/Entities/Zombies/ZBison/ZBison2.as
+++ b/Entities/Zombies/ZBison/ZBison2.as
@@ -22,9 +22,8 @@ void onInit(CBlob@ this)
 	this.set_f32("gib health", -3.5f);
     this.Tag("flesh");
 	
-	this.getCurrentScript().runFlags |= Script::tick_not_attached;
-	this.getCurrentScript().removeIfTag = "dead";
-	this.server_SetTimeToDie(20);
+        this.getCurrentScript().runFlags |= Script::tick_not_attached;
+        this.getCurrentScript().removeIfTag = "dead";
 }
 
 void onTick( CBlob@ this )

--- a/Entities/Zombies/Zombie/BloodZombie.as
+++ b/Entities/Zombies/Zombie/BloodZombie.as
@@ -23,9 +23,8 @@ void onInit(CBlob@ this)
 	this.set_f32("gib health", -3.0f);
     this.Tag("flesh");
 	
-	this.getCurrentScript().runFlags |= Script::tick_not_attached;
-	this.getCurrentScript().removeIfTag = "dead";
-	this.server_SetTimeToDie(20);	
+        this.getCurrentScript().runFlags |= Script::tick_not_attached;
+        this.getCurrentScript().removeIfTag = "dead";
 }
 
 void onTick(CBlob@ this)

--- a/Entities/Zombies/Zombie/EvilZombie.as
+++ b/Entities/Zombies/Zombie/EvilZombie.as
@@ -23,9 +23,8 @@ void onInit(CBlob@ this)
 	this.set_f32("gib health", -3.0f);
     this.Tag("flesh");
 	
-	this.getCurrentScript().runFlags |= Script::tick_not_attached;
-	this.getCurrentScript().removeIfTag = "dead";
-	this.server_SetTimeToDie(20);	
+        this.getCurrentScript().runFlags |= Script::tick_not_attached;
+        this.getCurrentScript().removeIfTag = "dead";
 }
 
 void onTick(CBlob@ this)

--- a/Entities/Zombies/Zombie/PlantZombie.as
+++ b/Entities/Zombies/Zombie/PlantZombie.as
@@ -23,9 +23,8 @@ void onInit(CBlob@ this)
 	this.set_f32("gib health", -3.0f);
     this.Tag("flesh");
 	
-	this.getCurrentScript().runFlags |= Script::tick_not_attached;
-	this.getCurrentScript().removeIfTag = "dead";
-	this.server_SetTimeToDie(20);	
+        this.getCurrentScript().runFlags |= Script::tick_not_attached;
+        this.getCurrentScript().removeIfTag = "dead";
 }
 
 void onTick(CBlob@ this)

--- a/Entities/Zombies/Zombie/Zombie2.as
+++ b/Entities/Zombies/Zombie/Zombie2.as
@@ -23,9 +23,8 @@ void onInit(CBlob@ this)
 	this.set_f32("gib health", -3.0f);
     this.Tag("flesh");
 	
-	this.getCurrentScript().runFlags |= Script::tick_not_attached;
-	this.getCurrentScript().removeIfTag = "dead";
-	this.server_SetTimeToDie(20);	
+        this.getCurrentScript().runFlags |= Script::tick_not_attached;
+        this.getCurrentScript().removeIfTag = "dead";
 }
 
 void onTick(CBlob@ this)


### PR DESCRIPTION
## Summary
- remove `server_SetTimeToDie` calls from zombie init scripts (Skeleton2, ZBison2, Zombie2, BloodZombie, PlantZombie, EvilZombie, Greg2)

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f01d9c3483339a6ffb2b045aeb34