### PR TITLE
Fix day timer and simplify difficulty

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Interface.as
+++ b/Rules/Scripts/Zombies/Zombies_Interface.as
@@ -24,12 +24,12 @@ const SColor COL_INFO      = SColor(255, 120, 180, 255); // blue-ish
 int GetCurrentDay(CRules@ rules)
 {
 	// Prefer HUD-provided day if present (snappier)
-	if (rules.exists("hud_dayNumber"))
-	{
-		int d = rules.get_s32("hud_dayNumber");
-		if (rules.exists("days_offset")) d += rules.get_s32("days_offset");
-		return Maths::Max(1, d);
-	}
+        if (rules.exists("hud_dayNumber"))
+        {
+                // hud_dayNumber already includes any day offset; avoid double counting
+                const int d = rules.get_s32("hud_dayNumber");
+                return Maths::Max(1, d);
+        }
 
 	// Fallback: compute from time
 	const int gamestart = rules.get_s32("gamestart");


### PR DESCRIPTION
## Summary
- fix day timer double counting offset
- streamline difficulty calculation and remove unused HUD variable

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a54af54208833399dbc2f81f523159