### PR TITLE
Normalize starting difficulty to account for map world state

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Config.as
+++ b/Rules/Scripts/Zombies/Zombies_Config.as
@@ -66,15 +66,16 @@ void RefreshMobCountsToRules()
 	getBlobsByTag("migrantbot", @a); getRules().set_s32("num_migrantbots",   a.length); a.clear();
 	getBlobsByTag("wraiths",    @a); getRules().set_s32("num_wraiths",       a.length); a.clear();
 	getBlobsByTag("gregs",      @a); getRules().set_s32("num_gregs",         a.length); a.clear();
-	getBlobsByTag("ruinstorch", @a); getRules().set_s32("num_ruinstorch",    a.length); a.clear();
+        getBlobsByTag("ruinstorch", @a); getRules().set_s32("num_ruinstorch",    a.length); a.clear();
 
 
-	// by exact blob name (bossy/specials we sometimes check directly)
-	getBlobsByName("zombieportal", @a); getRules().set_s32("num_zombiePortals", a.length); a.clear();
-	getBlobsByName("horror",       @a); getRules().set_s32("num_horror",        a.length); a.clear();
-	getBlobsByName("abomination",  @a); getRules().set_s32("num_abom",          a.length); a.clear();
-	getBlobsByName("immolator",    @a); getRules().set_s32("num_immol",         a.length); a.clear();
-	getBlobsByName("digger",       @a); getRules().set_s32("num_digger",        a.length); a.clear();
+        // by exact blob name (bossy/specials we sometimes check directly)
+        getBlobsByName("zombieportal", @a); getRules().set_s32("num_zombiePortals", a.length); a.clear();
+        getBlobsByName("horror",       @a); getRules().set_s32("num_horror",        a.length); a.clear();
+        getBlobsByName("abomination",  @a); getRules().set_s32("num_abom",          a.length); a.clear();
+        getBlobsByName("immolator",    @a); getRules().set_s32("num_immol",         a.length); a.clear();
+        getBlobsByName("digger",       @a); getRules().set_s32("num_digger",        a.length); a.clear();
+        getBlobsByName("zombiealter",  @a); getRules().set_s32("num_alters",        a.length); getRules().set_s32("zombiealter", a.length); a.clear();
 
 	// players by tag (already used elsewhere)
 	getBlobsByTag("survivorplayer", @a); getRules().set_s32("num_survivors", a.length); a.clear();

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -39,6 +39,15 @@ class ZombiesCore : RulesCore
 
         // seed counters once (single source of truth)
         RefreshMobCountsToRules();
+
+        // cache starting world state so difficulty begins at zero
+        float baseWorldMod = -0.3f;
+        baseWorldMod += rules.get_s32("num_ruinstorch") * 0.3f;
+        baseWorldMod -= rules.get_s32("num_alters") * 0.5f;
+        baseWorldMod += rules.get_s32("num_survivors") * 0.05f;
+        baseWorldMod -= rules.get_s32("num_undead") * 0.2f;
+        baseWorldMod += rules.get_s32("days_offset") * 0.1f;
+        rules.set_f32("base_world_mod", baseWorldMod);
     }
 
 	void Update()
@@ -58,11 +67,11 @@ class ZombiesCore : RulesCore
 		const int num_migrantbots   = rules.get_s32("num_migrantbots");
 		const int max_wraiths       = rules.get_s32("max_wraiths");
 		const int num_wraiths       = rules.get_s32("num_wraiths");
-		const int max_gregs         = rules.get_s32("max_gregs");
-		const int num_gregs         = rules.get_s32("num_gregs");
-		const int max_imol          = rules.get_s32("max_imol");
-		const int num_immol         = rules.get_s32("num_immol");
-		const int num_alters        = rules.get_s32("zombiealter");
+                const int max_gregs         = rules.get_s32("max_gregs");
+                const int num_gregs         = rules.get_s32("num_gregs");
+                const int max_imol          = rules.get_s32("max_imol");
+                const int num_immol         = rules.get_s32("num_immol");
+                const int num_alters        = rules.get_s32("num_alters");
 
 		// recompute simple derived values
         const int hardmode_day      = rules.get_s32("hardmode_day");
@@ -113,6 +122,10 @@ class ZombiesCore : RulesCore
         modified += survivors   * 0.05f;                  // more survivors hardens the waves
         modified -= undead      * 0.2f;                   // undead players make it tougher
         modified += days_offset * 0.1f;                 // manual day skips ups difficulty
+        if (rules.exists("base_world_mod"))
+        {
+            modified -= rules.get_f32("base_world_mod");   // normalize to starting state
+        }
 
         // persistent bonus from wipes (defaults to 0 if missing)
         float wipeBonus = rules.exists("difficulty_bonus") ? rules.get_f32("difficulty_bonus") : 0.0f;


### PR DESCRIPTION
## Summary
- Cache the initial world-state modifiers so difficulty begins at zero
- Subtract the cached value from later difficulty calculations
- Track altar counts during mob count refreshes

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a68c5559e083339044e25a8db222bd