### PR TITLE
Sync final difficulty with HUD and restore dirt backdrop on new ores

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Config.as
+++ b/Rules/Scripts/Zombies/Zombies_Config.as
@@ -16,6 +16,7 @@ void Config(ZombiesCore@ this)
         this.rules.set_f32("difficulty_bonus", 0.0f);
         this.rules.set_s32("last_wipe_day", -1);
         this.rules.set_s32("days_offset", 0);
+        this.rules.set_f32("finalDifficulty", 0.0f);
 
     // ----------------------------
     // Mob limits (hard caps)

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -162,6 +162,7 @@ class ZombiesCore : RulesCore
         if (finalDifficulty < 0.0f) finalDifficulty = 0.0f;
         if (finalDifficulty > 20.0f) finalDifficulty = 20.0f; // expanded cap
         rules.set_f32("difficulty", finalDifficulty);
+        rules.set_f32("finalDifficulty", finalDifficulty);
 
         int spawnRate = 90 - int(finalDifficulty * 3);
         if (spawnRate < 15) spawnRate = 15;

--- a/Rules/Scripts/Zombies/Zombies_Interface.as
+++ b/Rules/Scripts/Zombies/Zombies_Interface.as
@@ -26,9 +26,9 @@ int GetCurrentDay(CRules@ rules)
 	// Prefer HUD-provided day if present (snappier)
     if (rules.exists("hud_dayNumber"))
     {
-        // hud_dayNumber already includes any day offset; avoid double counting
-        const int d = rules.get_s32("hud_dayNumber");
-        return Maths::Max(1, d);
+	// hud_dayNumber already includes any day offset; avoid double counting
+	const int d = rules.get_s32("hud_dayNumber");
+	return Maths::Max(1, d);
     }
 
 	// Fallback: compute from time
@@ -41,21 +41,21 @@ int GetCurrentDay(CRules@ rules)
 // Consistent panel with soft border
 void DrawPanel(Vec2f tl, Vec2f br)
 {
-        GUI::DrawRectangle(tl, br, COL_BG);
-        GUI::DrawRectangle(tl, Vec2f(br.x, tl.y + 1), COL_BORDER);
-        GUI::DrawRectangle(Vec2f(tl.x, br.y - 1), br, COL_BORDER);
-        GUI::DrawRectangle(tl, Vec2f(tl.x + 1, br.y), COL_BORDER);
-        GUI::DrawRectangle(Vec2f(br.x - 1, tl.y), br, COL_BORDER);
+	GUI::DrawRectangle(tl, br, COL_BG);
+	GUI::DrawRectangle(tl, Vec2f(br.x, tl.y + 1), COL_BORDER);
+	GUI::DrawRectangle(Vec2f(tl.x, br.y - 1), br, COL_BORDER);
+	GUI::DrawRectangle(tl, Vec2f(tl.x + 1, br.y), COL_BORDER);
+	GUI::DrawRectangle(Vec2f(br.x - 1, tl.y), br, COL_BORDER);
 }
 
 // Helper to draw bold, centered titles
 void DrawTextCenteredBold(const string &in text, Vec2f pos, SColor color)
 {
-        GUI::DrawTextCentered(text, pos + Vec2f(-1, 0), color);
-        GUI::DrawTextCentered(text, pos + Vec2f(1, 0), color);
-        GUI::DrawTextCentered(text, pos + Vec2f(0, -1), color);
-        GUI::DrawTextCentered(text, pos + Vec2f(0, 1), color);
-        GUI::DrawTextCentered(text, pos, color);
+	GUI::DrawTextCentered(text, pos + Vec2f(-1, 0), color);
+	GUI::DrawTextCentered(text, pos + Vec2f(1, 0), color);
+	GUI::DrawTextCentered(text, pos + Vec2f(0, -1), color);
+	GUI::DrawTextCentered(text, pos + Vec2f(0, 1), color);
+	GUI::DrawTextCentered(text, pos, color);
 }
 
 // small helper for live player count by team
@@ -117,21 +117,21 @@ void onRender(CRules@ this)
 // behaviour.
 bool SafeGetSpawnSeconds(CRules@ rules, const string &in propname, u16 &out seconds)
 {
-        seconds = 0;
-        if (!rules.exists(propname)) return false;
+	seconds = 0;
+	if (!rules.exists(propname)) return false;
 
-        u16 candidate = rules.get_u16(propname);
+	u16 candidate = rules.get_u16(propname);
 
-        // Filter sentinels/garbage commonly used by scripts
-        // 255 is a common "not set" sentinel when stored as u8.
-        if (candidate == 255 || candidate == 65535) return false;
+	// Filter sentinels/garbage commonly used by scripts
+	// 255 is a common "not set" sentinel when stored as u8.
+	if (candidate == 255 || candidate == 65535) return false;
 
-        // Guard against nonsense (negative via wrap or way too large)
-        if (candidate > 3600) // 1h+ is unrealistic for revival seconds
-                return false;
+	// Guard against nonsense (negative via wrap or way too large)
+	if (candidate > 3600) // 1h+ is unrealistic for revival seconds
+	        return false;
 
-        seconds = candidate;
-        return true;
+	seconds = candidate;
+	return true;
 }
 
 
@@ -210,8 +210,8 @@ float DrawRecordStatus(CRules@ rules)
 
 	DrawPanel(tl, br);
 
-        DrawTextCenteredBold(title, Vec2f((tl.x + br.x) * 0.5f, tl.y + padY), COL_TITLE);
-        Vec2f cur = Vec2f(tl.x + padX, tl.y + padY + titleH + titleGap);
+	DrawTextCenteredBold(title, Vec2f((tl.x + br.x) * 0.5f, tl.y + padY), COL_TITLE);
+	Vec2f cur = Vec2f(tl.x + padX, tl.y + padY + titleH + titleGap);
 
 	for (uint i = 0; i < lines.length(); ++i)
 	{
@@ -240,15 +240,13 @@ float DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
 	const int   num_altars     = rules.get_s32("zombiealter");
 	const int   survivors      = CountTeamPlayers(0);
 	const int   undead         = rules.get_s32("num_undead");
-	const float difficulty     = rules.get_f32("difficulty");
-	const float diff_bonus     = rules.get_f32("difficulty_bonus");
-	const float diff_total     = difficulty + diff_bonus;
+	const float finalDifficulty = rules.get_f32("finalDifficulty");
 
 	array<string> lines;
 	lines.insertLast("Pillars: " + num_hands);
 	lines.insertLast("Survivors: " + survivors);
 	lines.insertLast("Undead: " + undead);
-        lines.insertLast("Difficulty: " + formatFloat(diff_total, "", 0, 1));
+	lines.insertLast("Difficulty: " + formatFloat(finalDifficulty, "", 0, 1));
 	lines.insertLast("Zombies: " + (num_zombies + num_pzombies) + "/" + max_zombies);
 	lines.insertLast("Altars Remaining: " + num_altars);
 

--- a/Scripts/MapLoaders/LoaderUtilities.as
+++ b/Scripts/MapLoaders/LoaderUtilities.as
@@ -86,7 +86,7 @@ TileType server_onTileHit(CMap@ map, f32 damage, u32 index, TileType oldTileType
 			case CMap::tile_ironore_d2:
 			case CMap::tile_ironore_d3:
 			case CMap::tile_ironore_d4:{OnIronTileHit(map, index); return oldTileType + 1;}		
-			case CMap::tile_ironore_d5: { OnIronTileDestroyed(map, index); return CMap::tile_empty;}		
+			case CMap::tile_ironore_d5: { OnIronTileDestroyed(map, index); return CMap::tile_ground_back;}
 
 			//Coal Ore
 			case CMap::tile_coalore: {OnCoalTileHit(map, index); return CMap::tile_coalore_d0;}	
@@ -95,7 +95,7 @@ TileType server_onTileHit(CMap@ map, f32 damage, u32 index, TileType oldTileType
 			case CMap::tile_coalore_d2:
 			case CMap::tile_coalore_d3:
 			case CMap::tile_coalore_d4:{OnCoalTileHit(map, index); return oldTileType + 1;}		
-			case CMap::tile_coalore_d5: { OnCoalTileDestroyed(map, index); return CMap::tile_empty;}		
+			case CMap::tile_coalore_d5: { OnCoalTileDestroyed(map, index); return CMap::tile_ground_back;}
 
 			//Copper Ore
 			case CMap::tile_copperore: {OnCopperTileHit(map, index); return CMap::tile_copperore_d0;}	
@@ -104,7 +104,7 @@ TileType server_onTileHit(CMap@ map, f32 damage, u32 index, TileType oldTileType
 			case CMap::tile_copperore_d2:
 			case CMap::tile_copperore_d3:
 			case CMap::tile_copperore_d4:{OnCopperTileHit(map, index); return oldTileType + 1;}		
-			case CMap::tile_copperore_d5: { OnCopperTileDestroyed(map, index); return CMap::tile_empty;}	
+			case CMap::tile_copperore_d5: { OnCopperTileDestroyed(map, index); return CMap::tile_ground_back;}
 
 			//BLOOD DIRT
 			case CMap::tile_littlebloodground:


### PR DESCRIPTION
## Summary
- Expose `finalDifficulty` in core and reset it in config
- Use `finalDifficulty` in round status HUD
- Leave dirt background after destroying coal, iron, or copper ore tiles

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a69eec1e188333a6c81e9f94d1d1da