### PR TITLE
Refactor difficulty system

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Config.as
+++ b/Rules/Scripts/Zombies/Zombies_Config.as
@@ -16,7 +16,7 @@ void Config(ZombiesCore@ this)
         this.rules.set_f32("difficulty_bonus", 0.0f);
         this.rules.set_s32("last_wipe_day", -1);
         this.rules.set_s32("days_offset", 0);
-        this.rules.set_f32("finalDifficulty", 0.0f);
+        this.rules.set_f32("difficulty", 0.0f);
 
     // ----------------------------
     // Mob limits (hard caps)

--- a/Rules/Scripts/Zombies/Zombies_Interface.as
+++ b/Rules/Scripts/Zombies/Zombies_Interface.as
@@ -240,13 +240,13 @@ float DrawZombiesHUDTopRight(CRules@ rules, const float topOffset = 0.0f)
 	const int   num_altars     = rules.get_s32("zombiealter");
 	const int   survivors      = CountTeamPlayers(0);
 	const int   undead         = rules.get_s32("num_undead");
-	const float finalDifficulty = rules.get_f32("finalDifficulty");
+        const float difficulty = rules.get_f32("difficulty");
 
 	array<string> lines;
 	lines.insertLast("Pillars: " + num_hands);
 	lines.insertLast("Survivors: " + survivors);
 	lines.insertLast("Undead: " + undead);
-	lines.insertLast("Difficulty: " + formatFloat(finalDifficulty, "", 0, 1));
+        lines.insertLast("Difficulty: " + formatFloat(difficulty, "", 0, 1));
 	lines.insertLast("Zombies: " + (num_zombies + num_pzombies) + "/" + max_zombies);
 	lines.insertLast("Altars Remaining: " + num_altars);
 


### PR DESCRIPTION
## Summary
- simplify difficulty tracking to a single `difficulty` value
- remove base world modifiers and compute difficulty from day count and world state
- update HUD and configuration to read the unified difficulty value

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a6a4cfd3a48333afbcc04c9ca44f59