### PR TITLE
Reset respawn timers on map change

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Main.as
+++ b/Rules/Scripts/Zombies/Zombies_Main.as
@@ -48,8 +48,9 @@ void Reset(CRules@ this)
                         p.set_u8("killstreak", 0);
 
                         // clear any leftover respawn timer from the previous round
+                        // so everyone spawns instantly on the new map
                         const string propname = "Zombies spawn time " + p.getUsername();
-                        this.set_u16(propname, 255);
+                        this.set_u16(propname, 0);
                         this.SyncToPlayer(propname, p);
                 }
         }


### PR DESCRIPTION
## Summary
- Ensure respawn timers are zeroed at round reset so everyone spawns instantly on the next map

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a6b0ac64a4833383d90d04c9dc6fee