### PR TITLE
Fix daytime zombie spawning and add weather commands

### DIFF
--- a/Rules/Scripts/Utilities/ChatCommands.as
+++ b/Rules/Scripts/Utilities/ChatCommands.as
@@ -8,7 +8,7 @@
 //#include "RPC_War.as";
 #include "RulesCore.as";
 #include "Core/Structs.as";
-#include "WeatherSystem.as";
+shared void TriggerStorm(CRules@ this, const string &in blobname);
 
 bool onServerProcessChat( CRules@ this, const string& in text_in, string& out text_out, CPlayer@ player )
 {
@@ -196,10 +196,20 @@ bool onServerProcessChat( CRules@ this, const string& in text_in, string& out te
     {
         getMap().server_setFloodWaterWorldspace(blob.getPosition(),true);
     }
-	else if (text_in == "!seed")
-	{
-		// crash prevention
-	}
+    else if (text_in == "!storm" && player.isMod())
+    {
+        TriggerStorm(this, "rain");
+        return false;
+    }
+    else if (text_in == "!hellfire" && player.isMod())
+    {
+        TriggerStorm(this, "hellfire");
+        return false;
+    }
+        else if (text_in == "!seed")
+        {
+                // crash prevention
+        }
     else if (text_in == "!killme")
     {
         blob.server_Hit( blob, blob.getPosition(), Vec2f(0,0), 4.0f, 0);

--- a/Rules/Scripts/Weather/WeatherSystem.as
+++ b/Rules/Scripts/Weather/WeatherSystem.as
@@ -63,6 +63,25 @@ void onTick(CRules@ this)
 		}
 	}
 
-	// Schedule the next chance window after this weather plus a cooldown
+        // Schedule the next chance window after this weather plus a cooldown
+        g_next_weather = time + length_ticks + 20000 + XORRandom(150000);
+}
+
+shared void TriggerStorm(CRules@ this, const string &in blobname)
+{
+        const u32 time = getGameTime();
+        const u32 length_ticks = (30 * 60 * 1) + XORRandom(30 * 60 * 5);
+
+        if (!this.get_bool("raining"))
+        {
+                CBlob@ weather = server_CreateBlob(blobname, 255, Vec2f(0, 0));
+                if (weather !is null)
+                {
+                        weather.server_SetTimeToDie(length_ticks / 30.0f);
+                        this.set_bool("raining", true);
+                        this.set_u32("rain_end_at", time + length_ticks);
+                }
+        }
+
         g_next_weather = time + length_ticks + 20000 + XORRandom(150000);
 }

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -75,7 +75,7 @@ class ZombiesCore : RulesCore
         const int dayNumber         = days_offset + ((getGameTime() - gamestart) / getTicksASecond() / day_cycle) + 1;
 
         const int timeElapsed  = getGameTime() - gamestart;
-        const int ignore_light = (hardmode_day - ((days_offset / 14) * 10));
+        const bool hardmode    = (dayNumber >= hardmode_day);
 
 		// quick player team pass (used for max_undead)
 		int num_survivors_p = 0;
@@ -279,9 +279,9 @@ class ZombiesCore : RulesCore
 				const int _num_di = rules.get_s32("num_digger");
 				const int _max_di = rules.get_s32("max_digger");
 
-				const bool canSpawnNow =
-					   (dayNumber >= ignore_light && _num_z < max_zombies)
-					|| (rules.hasTag("night")     && _num_z < max_zombies);
+                                const bool canSpawnNow =
+                                        (hardmode || rules.hasTag("night"))
+                                        && (_num_z < max_zombies);
 
 				if (canSpawnNow)
 				{


### PR DESCRIPTION
## Summary
- prevent daytime zombie spawns before hardmode by respecting night and hardmode thresholds
- add `!storm` and `!hellfire` chat commands to trigger rain or hellfire

## Testing
- `python3 -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c637c96c8333979145b0dd2aa18a