### PR TITLE
Fix storm command compilation errors

### DIFF
--- a/Rules/Scripts/Weather/WeatherSystem.as
+++ b/Rules/Scripts/Weather/WeatherSystem.as
@@ -4,7 +4,7 @@
 // Randomly triggers either rain or hell fire with a cooldown.
 // No map-type checks. Keeps a simple "raining" flag while active.
 
-u32 g_next_weather = 1000;
+shared u32 g_next_weather = 1000;
 const u8 HELLFIRE_PERCENT = 10; // 0–100 chance; set lower if you want hell fire to be rarer
 
 void onInit(CRules@ this)


### PR DESCRIPTION
## Summary
- Make `g_next_weather` a shared variable so `TriggerStorm` can access it

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a6c89e8c348333aed28c18a8f1e078