### PR TITLE
Remove weather chat commands

### DIFF
--- a/Rules/Scripts/Utilities/ChatCommands.as
+++ b/Rules/Scripts/Utilities/ChatCommands.as
@@ -8,7 +8,7 @@
 //#include "RPC_War.as";
 #include "RulesCore.as";
 #include "Core/Structs.as";
-shared void TriggerStorm(CRules@ this, const string &in blobname);
+#include "WeatherSystem.as";
 
 bool onServerProcessChat( CRules@ this, const string& in text_in, string& out text_out, CPlayer@ player )
 {
@@ -196,20 +196,10 @@ bool onServerProcessChat( CRules@ this, const string& in text_in, string& out te
     {
         getMap().server_setFloodWaterWorldspace(blob.getPosition(),true);
     }
-    else if (text_in == "!storm" && player.isMod())
-    {
-        TriggerStorm(this, "rain");
-        return false;
-    }
-    else if (text_in == "!hellfire" && player.isMod())
-    {
-        TriggerStorm(this, "hellfire");
-        return false;
-    }
-        else if (text_in == "!seed")
-        {
-                // crash prevention
-        }
+	else if (text_in == "!seed")
+	{
+		// crash prevention
+	}
     else if (text_in == "!killme")
     {
         blob.server_Hit( blob, blob.getPosition(), Vec2f(0,0), 4.0f, 0);

--- a/Rules/Scripts/Weather/WeatherSystem.as
+++ b/Rules/Scripts/Weather/WeatherSystem.as
@@ -4,7 +4,7 @@
 // Randomly triggers either rain or hell fire with a cooldown.
 // No map-type checks. Keeps a simple "raining" flag while active.
 
-shared u32 g_next_weather = 1000;
+u32 g_next_weather = 1000;
 const u8 HELLFIRE_PERCENT = 10; // 0–100 chance; set lower if you want hell fire to be rarer
 
 void onInit(CRules@ this)
@@ -63,25 +63,6 @@ void onTick(CRules@ this)
 		}
 	}
 
-        // Schedule the next chance window after this weather plus a cooldown
-        g_next_weather = time + length_ticks + 20000 + XORRandom(150000);
-}
-
-shared void TriggerStorm(CRules@ this, const string &in blobname)
-{
-        const u32 time = getGameTime();
-        const u32 length_ticks = (30 * 60 * 1) + XORRandom(30 * 60 * 5);
-
-        if (!this.get_bool("raining"))
-        {
-                CBlob@ weather = server_CreateBlob(blobname, 255, Vec2f(0, 0));
-                if (weather !is null)
-                {
-                        weather.server_SetTimeToDie(length_ticks / 30.0f);
-                        this.set_bool("raining", true);
-                        this.set_u32("rain_end_at", time + length_ticks);
-                }
-        }
-
+	// Schedule the next chance window after this weather plus a cooldown
         g_next_weather = time + length_ticks + 20000 + XORRandom(150000);
 }


### PR DESCRIPTION
## Summary
- remove storm and hellfire chat commands
- restore WeatherSystem to autonomous random storms

## Testing
- `rg TriggerStorm -n`
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68a6d3c144588333b98183158a543fd9