### PR TITLE
Add spawn caps for banshees, horrors, and gasbags

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Config.as
+++ b/Rules/Scripts/Zombies/Zombies_Config.as
@@ -25,11 +25,14 @@ void Config(ZombiesCore@ this)
 	this.rules.set_s32("max_zombies",     250);   // standard zombies
 	this.rules.set_s32("max_pzombies",    25);    // portal-spawned zombies
 	this.rules.set_s32("max_migrantbots", 4);     // migrants
-	this.rules.set_s32("max_wraiths",     20);
-	this.rules.set_s32("max_gregs",       10);
-	this.rules.set_s32("max_imol",        5);
-	this.rules.set_s32("max_digger",      5);
-	this.rules.set_s32("max_bison",       8);
+        this.rules.set_s32("max_wraiths",     20);
+        this.rules.set_s32("max_gregs",       10);
+        this.rules.set_s32("max_imol",        5);
+        this.rules.set_s32("max_digger",      5);
+        this.rules.set_s32("max_bison",       8);
+        this.rules.set_s32("max_banshees",    6);
+        this.rules.set_s32("max_horror",      8);
+        this.rules.set_s32("max_gasbags",     10);
 
 	// ----------------------------
 	// Win/Loss pacing
@@ -75,6 +78,8 @@ void RefreshMobCountsToRules()
     // by exact blob name (bossy/specials we sometimes check directly)
     getBlobsByName("zombieportal", @a); getRules().set_s32("num_zombiePortals", a.length); a.clear();
     getBlobsByName("horror",       @a); getRules().set_s32("num_horror",        a.length); a.clear();
+    getBlobsByName("pbanshee",     @a); getRules().set_s32("num_banshees",     a.length); a.clear();
+    getBlobsByName("gasbag",       @a); getRules().set_s32("num_gasbags",      a.length); a.clear();
     getBlobsByName("abomination",  @a); getRules().set_s32("num_abom",          a.length); a.clear();
     getBlobsByName("immolator",    @a); getRules().set_s32("num_immol",         a.length); a.clear();
     getBlobsByName("digger",       @a); getRules().set_s32("num_digger",        a.length); a.clear();

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -57,14 +57,20 @@ class ZombiesCore : RulesCore
 		const int num_zombies       = rules.get_s32("num_zombies");
 		const int max_pzombies      = rules.get_s32("max_pzombies");
 		const int num_pzombies      = rules.get_s32("num_pzombies");
-		const int max_migrantbots   = rules.get_s32("max_migrantbots");
-		const int num_migrantbots   = rules.get_s32("num_migrantbots");
-		const int max_wraiths       = rules.get_s32("max_wraiths");
-		const int num_wraiths       = rules.get_s32("num_wraiths");
+                const int max_migrantbots   = rules.get_s32("max_migrantbots");
+                const int num_migrantbots   = rules.get_s32("num_migrantbots");
+                const int max_wraiths       = rules.get_s32("max_wraiths");
+                const int num_wraiths       = rules.get_s32("num_wraiths");
         const int max_gregs         = rules.get_s32("max_gregs");
         const int num_gregs         = rules.get_s32("num_gregs");
         const int max_imol          = rules.get_s32("max_imol");
         const int num_immol         = rules.get_s32("num_immol");
+        const int max_banshees      = rules.get_s32("max_banshees");
+        const int num_banshees      = rules.get_s32("num_banshees");
+        const int max_horror        = rules.get_s32("max_horror");
+        const int num_horror        = rules.get_s32("num_horror");
+        const int max_gasbags       = rules.get_s32("max_gasbags");
+        const int num_gasbags       = rules.get_s32("num_gasbags");
         const int num_alters        = rules.get_s32("num_alters");
 
 		// recompute simple derived values
@@ -269,16 +275,22 @@ class ZombiesCore : RulesCore
 				Vec2f sp = zombiePlaces[XORRandom(zombiePlaces.length)];
 
 				// read current caps/counters from rules (already refreshed)
-				const int _num_wr = rules.get_s32("num_wraiths");
-				const int _max_wr = rules.get_s32("max_wraiths");
-				const int _num_gr = rules.get_s32("num_gregs");
-				const int _max_gr = rules.get_s32("max_gregs");
-				const int _num_im = rules.get_s32("num_immol");
-				const int _max_im = rules.get_s32("max_imol");
-				const int _num_di = rules.get_s32("num_digger");
-				const int _max_di = rules.get_s32("max_digger");
-				const int _num_bi = rules.get_s32("num_bisons");
-				const int _max_bi = rules.get_s32("max_bisons");
+                                const int _num_wr = rules.get_s32("num_wraiths");
+                                const int _max_wr = rules.get_s32("max_wraiths");
+                                const int _num_gr = rules.get_s32("num_gregs");
+                                const int _max_gr = rules.get_s32("max_gregs");
+                                const int _num_im = rules.get_s32("num_immol");
+                                const int _max_im = rules.get_s32("max_imol");
+                                const int _num_di = rules.get_s32("num_digger");
+                                const int _max_di = rules.get_s32("max_digger");
+                                const int _num_bi = rules.get_s32("num_bisons");
+                                const int _max_bi = rules.get_s32("max_bisons");
+                                const int _num_ba = rules.get_s32("num_banshees");
+                                const int _max_ba = rules.get_s32("max_banshees");
+                                const int _num_ho = rules.get_s32("num_horror");
+                                const int _max_ho = rules.get_s32("max_horror");
+                                const int _num_ga = rules.get_s32("num_gasbags");
+                                const int _max_ga = rules.get_s32("max_gasbags");
 
                 const bool canSpawnNow = (hardmode || isNight) && (num_zombies < max_zombies);
 
@@ -289,14 +301,14 @@ class ZombiesCore : RulesCore
 
 					if      (r >=  19.0f && _num_di < _max_di)                               server_CreateBlob("digger", -1, sp);
 					else if (r >=  16.0f && (_num_gr + _num_wr) < (_max_gr + _max_wr))       server_CreateBlob("writher", -1, sp);
-					else if (r >=  13.0f)                                                    server_CreateBlob("pbanshee", -1, sp);
-					else if (r >=  11.0f && _num_bi < _max_bi)                               { const u8 v = XORRandom(2); server_CreateBlob((v == 0 ? "zbison" : "zbison2"), -1, sp); }
-					else if (r >=  9.5f)                                                     server_CreateBlob("horror", -1, sp);
-					else if (r >=  9.0f && _num_wr < _max_wr)                                { const u8 v = XORRandom(2); server_CreateBlob((v == 0 ? "wraith" : "wraith2"), -1, sp); }
-					else if (r >=  8.0f && _num_gr < _max_gr)                                { const u8 v = XORRandom(2); server_CreateBlob((v == 0 ? "greg" : "greg2"), -1, sp); }
-					else if (r >=  6.5f && _num_im < _max_im)                                server_CreateBlob("immolator", -1, sp);
-					else if (r >=  5.0f)                                                     server_CreateBlob("gasbag", -1, sp);
-					else if (r >=  3.5f)                                                     server_CreateBlob("zombieknight", -1, sp);
+                                        else if (r >=  13.0f && _num_ba < _max_ba)                               server_CreateBlob("pbanshee", -1, sp);
+                                        else if (r >=  11.0f && _num_bi < _max_bi)                               { const u8 v = XORRandom(2); server_CreateBlob((v == 0 ? "zbison" : "zbison2"), -1, sp); }
+                                        else if (r >=  9.5f && _num_ho < _max_ho)                                server_CreateBlob("horror", -1, sp);
+                                        else if (r >=  9.0f && _num_wr < _max_wr)                                { const u8 v = XORRandom(2); server_CreateBlob((v == 0 ? "wraith" : "wraith2"), -1, sp); }
+                                        else if (r >=  8.0f && _num_gr < _max_gr)                                { const u8 v = XORRandom(2); server_CreateBlob((v == 0 ? "greg" : "greg2"), -1, sp); }
+                                        else if (r >=  6.5f && _num_im < _max_im)                                server_CreateBlob("immolator", -1, sp);
+                                        else if (r >=  5.0f && _num_ga < _max_ga)                                server_CreateBlob("gasbag", -1, sp);
+                                        else if (r >=  3.5f)                                                     server_CreateBlob("zombieknight", -1, sp);
                     else if (r >=  2.0f)                                                     { const u8 v = XORRandom(3); server_CreateBlob(v == 0 ? "evilzombie" : (v == 1 ? "bloodzombie" : "plantzombie"), -1, sp); }
                     else if (r >=  1.0f)                                                     { const u8 v = XORRandom(2); server_CreateBlob((v == 0 ? "zombie" : "zombie2"), -1, sp); }
                     else if (r >=  0.5f)                                                     { const u8 v = XORRandom(2); server_CreateBlob((v == 0 ? "skeleton" : "skeleton2"), -1, sp); }


### PR DESCRIPTION
## Summary
- allow configuring max banshees, horrors, and gasbags
- track current banshee and gasbag counts for cap enforcement
- prevent spawning these mobs once their caps are reached

## Testing
- `npm test` *(fails: package.json missing)*
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68a71c27b678833380a7f8360788b8fd