### PR TITLE
Ensure game over popup and record saving

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -452,19 +452,21 @@ class ZombiesCore : RulesCore
 		CBlob @[] bases;
 		getBlobsByName(base_name(), @bases);
 
-		// Game over if pillars are gone
-		if (bases.length == 0)
-		{
-			rules.SetTeamWon(1);
-			rules.SetCurrentState(GAME_OVER);
-			Server_GlobalPopup(rules,
-							   "Gameover!\nThe Pillars Have Been destroyed\nOn day " +
-								   (dayNumber + days_offset) + ".",
-							   SColor(255, 255, 0, 0),
-							   10 * getTicksASecond());
-			return;
-		}
-	}
+                // Game over if pillars are gone
+                if (bases.length == 0)
+                {
+                        // announce before changing state so the message has time to sync
+                        Server_GlobalPopup(rules,
+                                                           "Gameover!\nThe Pillars Have Been destroyed\nOn day " +
+                                                                   (dayNumber + days_offset) + ".",
+                                                           SColor(255, 255, 0, 0),
+                                                           10 * getTicksASecond());
+
+                        rules.SetTeamWon(1);
+                        rules.SetCurrentState(GAME_OVER);
+                        return;
+                }
+        }
 
 	void addKill(int team)
 	{

--- a/Rules/Scripts/Zombies/Zombies_Records.as
+++ b/Rules/Scripts/Zombies/Zombies_Records.as
@@ -74,37 +74,37 @@ void onTick(CRules @ this) {
   }
 
   this.set_u16("day_number", getDaysSurvived(this));
-
-  if (this.isGameOver() && !this.get_bool("records_saved")) {
-    this.set_bool("records_saved", true);
-    const u16 days = getDaysSurvived(this);
-    const u32 kills = this.get_u32("undead_kills");
-    if (!this.get_bool("dayCheated")) {
-      u16 mapRec = this.get_u16("map_record");
-      u16 globRec = this.get_u16("global_record");
-      u32 mapKillRec = this.get_u32("map_kill_record");
-      u32 globKillRec = this.get_u32("global_kill_record");
-
-      if (days > mapRec)
-        this.set_u16("map_record", days);
-      if (days > globRec)
-        this.set_u16("global_record", days);
-      if (kills > mapKillRec)
-        this.set_u32("map_kill_record", kills);
-      if (kills > globKillRec)
-        this.set_u32("global_kill_record", kills);
-
-      SaveRecords(this);
-      this.Sync("map_record", true);
-      this.Sync("global_record", true);
-      this.Sync("map_kill_record", true);
-      this.Sync("global_kill_record", true);
-    }
-  }
 }
 
 void onStateChange(CRules @ this, const u8 oldState) {
-  if (!this.isGameOver()) {
+  if (this.isGameOver()) {
+    if (!this.get_bool("records_saved")) {
+      this.set_bool("records_saved", true);
+      const u16 days = getDaysSurvived(this);
+      const u32 kills = this.get_u32("undead_kills");
+      if (!this.get_bool("dayCheated")) {
+        u16 mapRec = this.get_u16("map_record");
+        u16 globRec = this.get_u16("global_record");
+        u32 mapKillRec = this.get_u32("map_kill_record");
+        u32 globKillRec = this.get_u32("global_kill_record");
+
+        if (days > mapRec)
+          this.set_u16("map_record", days);
+        if (days > globRec)
+          this.set_u16("global_record", days);
+        if (kills > mapKillRec)
+          this.set_u32("map_kill_record", kills);
+        if (kills > globKillRec)
+          this.set_u32("global_kill_record", kills);
+
+        SaveRecords(this);
+        this.Sync("map_record", true);
+        this.Sync("global_record", true);
+        this.Sync("map_kill_record", true);
+        this.Sync("global_kill_record", true);
+      }
+    }
+  } else {
     this.set_bool("records_saved", false);
   }
 }


### PR DESCRIPTION
## Summary
- show gameover popup before changing rules state
- save zombie records when game enters GAME_OVER

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a727e68a748333b7849c05d7eefe11