### PR TITLE
Fix record file path to save safely

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Records.as
+++ b/Rules/Scripts/Zombies/Zombies_Records.as
@@ -1,7 +1,7 @@
 #define SERVER_ONLY
 
-// store records outside of the scripts directory like Zombies_Reborn
-const string records_file = "../Cache/ZombieRecords.cfg";
+// store records inside the Cache directory to allow saving
+const string records_file = "Cache/ZombieRecords.cfg";
 
 u16 getDaysSurvived(CRules @rules)
 {


### PR DESCRIPTION
## Summary
- save zombie survival records to `Cache/ZombieRecords.cfg` instead of an unsafe parent-relative path

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a737b4f0c0833384975bd1fb98e745