### PR TITLE
Fix weather lightning crash and record persistence

### DIFF
--- a/Rules/Scripts/Weather/LightningBolt/LightningBolt.as
+++ b/Rules/Scripts/Weather/LightningBolt/LightningBolt.as
@@ -15,12 +15,23 @@ void onInit(CBlob@ this)
 
 	if (isServer())
 	{
-		for (int i = 0; i < 4 + XORRandom(4); i++)
-		{
-			CBlob@ blob = server_CreateBlob("flame", -1, strikePos + Vec2f(0.0f, -map.tilesize));
-			blob.setVelocity(Vec2f(XORRandom(40) / 10.0f - 2.0f, -XORRandom(20) / 10.0f));
-			blob.server_SetTimeToDie(4 + XORRandom(6));
-		}
+                for (int i = 0; i < 4 + XORRandom(4); i++)
+                {
+                        // The old code attempted to spawn a blob named "flame" which
+                        // doesn't exist in this mod, resulting in null blobs and noisy
+                        // "Config file not found" errors followed by a null-pointer
+                        // access.  Spawn the existing "fireblob" instead and guard
+                        // against creation failure.
+                        CBlob@ blob =
+                                server_CreateBlob("fireblob", -1,
+                                                                 strikePos + Vec2f(0.0f, -map.tilesize));
+                        if (blob !is null)
+                        {
+                                blob.setVelocity(Vec2f(XORRandom(40) / 10.0f - 2.0f,
+                                                                 -XORRandom(20) / 10.0f));
+                                blob.server_SetTimeToDie(4 + XORRandom(6));
+                        }
+                }
 
 		CBlob@[] blobs;
 		map.getBlobsInRadius(strikePos, 48.0f, @blobs);

--- a/Rules/Scripts/Zombies/Zombies_Interface.as
+++ b/Rules/Scripts/Zombies/Zombies_Interface.as
@@ -113,7 +113,7 @@ void onRender(CRules @ this)
 // ------------------------------
 // Revival timer centered on top
 // ------------------------------
-// Safely read "Zombies spawn time <username>".
+// Safely read "zg spawn time <username>".
 // Returns: (true, seconds>=0) when present & valid; otherwise (false, 0).
 //
 // The property is consistently stored as u16. Previous code attempted to read
@@ -154,7 +154,7 @@ void DrawRevivalTimer(CRules @rules, CPlayer @p)
 	if (myBlob !is null)
 		return;
 
-	const string propname = "Zombies spawn time " + p.getUsername();
+        const string propname = "zg spawn time " + p.getUsername();
 
 	u16 spawnSec = 0;
 	if (!SafeGetSpawnSeconds(rules, propname, spawnSec))

--- a/Rules/Scripts/Zombies/Zombies_Main.as
+++ b/Rules/Scripts/Zombies/Zombies_Main.as
@@ -58,9 +58,15 @@ void Reset(CRules @ this)
 
 			// clear any leftover respawn timer from the previous round
 			// so everyone spawns instantly on the new map
-			const string propname = "Zombies spawn time " + p.getUsername();
-			this.set_u16(propname, 0);
-			this.SyncToPlayer(propname, p);
+                        // Track each player's respawn countdown using a unique
+                        // property name.  The previous implementation used
+                        // "Zombies spawn time" which clashed with scripts that
+                        // accessed the property as a u8 and spammed the console
+                        // with type‑mismatch warnings.  Using a mod‑specific
+                        // prefix avoids the conflict.
+                        const string propname = "zg spawn time " + p.getUsername();
+                        this.set_u16(propname, 0);
+                        this.SyncToPlayer(propname, p);
 		}
 	}
 

--- a/Rules/Scripts/Zombies/Zombies_Records.as
+++ b/Rules/Scripts/Zombies/Zombies_Records.as
@@ -1,7 +1,12 @@
 #define SERVER_ONLY
 
-// store records outside of the scripts directory
-const string records_file = "Cache/ZombieRecords.cfg";
+// Store records alongside the mod instead of the game's root Cache
+// folder.  Previously this pointed at "Cache/ZombieRecords.cfg" which
+// resolved to Base/Cache when running in‑game.  As a result the file in
+// Mods/ZombieGarden_dev/Cache was never updated and players couldn't see
+// their new records.  Use the explicit mod path so the file we ship gets
+// updated and persists between runs.
+const string records_file = "../Mods/ZombieGarden_dev/Cache/ZombieRecords.cfg";
 
 u16 getDaysSurvived(CRules @rules)
 {

--- a/Rules/Scripts/Zombies/Zombies_Spawns.as
+++ b/Rules/Scripts/Zombies/Zombies_Spawns.as
@@ -73,7 +73,9 @@ class ZombiesSpawns : RespawnSystem
 				info.can_spawn_time = 0;
 			}
 
-			string propname = "Zombies spawn time " + info.username;
+                        // Use mod-specific property to avoid conflicts with other
+                        // scripts expecting a different type for "Zombies spawn time".
+                        string propname = "zg spawn time " + info.username;
 
 			Zombies_core.rules.set_u16(propname, spawn_property);
 			Zombies_core.rules.SyncToPlayer(propname,
@@ -298,7 +300,7 @@ class ZombiesSpawns : RespawnSystem
 			return;
 		}
 
-		string propname = "Zombies spawn time " + info.username;
+            string propname = "zg spawn time " + info.username;
 
 		for (uint i = 0; i < Zombies_core.teams.length; i++)
 		{
@@ -378,15 +380,18 @@ class ZombiesSpawns : RespawnSystem
 			team.spawns.push_back(info);
 
 			// Seed the client HUD timer (u8 seconds, 255 = ready)
-			const string hudKey = "Zombies spawn time " + player.getUsername();
-			u8 hudSecs = 255;
-			if (tickspawndelay > 0)
-			{
-				int s = tickspawndelay / getTicksASecond();
-				hudSecs = u8(Maths::Clamp(s, 0, 254));
-			}
-			getRules().set_u8(hudKey, hudSecs);
-			getRules().Sync(hudKey, true);
+                    const string hudKey = "zg spawn time " + player.getUsername();
+                        // store HUD seconds as u16 to match server property and
+                        // avoid type-mismatch warnings.  65535 acts as the
+                        // "ready" sentinel used by SafeGetSpawnSeconds.
+                        u16 hudSecs = 65535;
+                        if (tickspawndelay > 0)
+                        {
+                                int s = tickspawndelay / getTicksASecond();
+                                hudSecs = u16(Maths::Clamp(s, 0, 65534));
+                        }
+                        getRules().set_u16(hudKey, hudSecs);
+                        getRules().Sync(hudKey, true);
 		}
 		else
 		{


### PR DESCRIPTION
## Summary
- Replace missing `flame` blob with existing `fireblob` and guard against nulls
- Save survival records to the mod's Cache directory
- Rename spawn-time properties and store them as `u16` to avoid type mismatches

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a74f9738f4833380b354ec3cfe69d6