### PR TITLE
Fix record saving path

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Records.as
+++ b/Rules/Scripts/Zombies/Zombies_Records.as
@@ -1,12 +1,11 @@
 #define SERVER_ONLY
 
-// Store records alongside the mod instead of the game's root Cache
-// folder.  Previously this pointed at "Cache/ZombieRecords.cfg" which
-// resolved to Base/Cache when running in‑game.  As a result the file in
-// Mods/ZombieGarden_dev/Cache was never updated and players couldn't see
-// their new records.  Use the explicit mod path so the file we ship gets
-// updated and persists between runs.
-const string records_file = "../Mods/ZombieGarden_dev/Cache/ZombieRecords.cfg";
+// Store records in the game's Cache folder.  Writing directly to the mod
+// directory is disallowed by the engine's security checks and results in
+// "Cannot save files in a different directory than Cache" errors.  Using an
+// explicit path inside Cache ensures the records persist between runs
+// without triggering those errors.
+const string records_file = "../Cache/ZombieRecords.cfg";
 
 u16 getDaysSurvived(CRules @rules)
 {


### PR DESCRIPTION
## Summary
- store zombie records in the game's Cache folder to avoid security errors when saving

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: no files)*

------
https://chatgpt.com/codex/tasks/task_e_68a75e7cedb88333a490c6a3c50c4dd2