### PR TITLE
Use Cache-relative saving for records

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Records.as
+++ b/Rules/Scripts/Zombies/Zombies_Records.as
@@ -5,7 +5,8 @@
 // "Cannot save files in a different directory than Cache" errors.  Using an
 // explicit path inside Cache ensures the records persist between runs
 // without triggering those errors.
-const string records_file = "../Cache/ZombieRecords.cfg";
+const string records_file_name = "ZombieRecords.cfg";
+const string records_file_path = "../Cache/" + records_file_name;
 
 u16 getDaysSurvived(CRules @rules)
 {
@@ -32,11 +33,11 @@ void onRestart(CRules @ this)
 
 void LoadRecords(CRules @ this)
 {
-	ConfigFile cfg;
-	if (!cfg.loadFile(records_file))
-	{
-		cfg.saveFile(records_file);
-	}
+        ConfigFile cfg;
+        if (!cfg.loadFile(records_file_path))
+        {
+                cfg.saveFile(records_file_name);
+        }
 	string map = this.get_string("map_name");
 	if (map == "" && getMap() !is null)
 	{
@@ -58,11 +59,11 @@ void LoadRecords(CRules @ this)
 
 void SaveRecords(CRules @ this)
 {
-	ConfigFile cfg;
-	if (!cfg.loadFile(records_file))
-	{
-		cfg.saveFile(records_file);
-	}
+        ConfigFile cfg;
+        if (!cfg.loadFile(records_file_path))
+        {
+                cfg.saveFile(records_file_name);
+        }
 	string map = this.get_string("map_name");
 	if (map == "" && getMap() !is null)
 	{
@@ -70,10 +71,10 @@ void SaveRecords(CRules @ this)
 		this.set_string("map_name", map);
 	}
 	cfg.add_u16("map_" + map, this.get_u16("map_record"));
-	cfg.add_u16("global", this.get_u16("global_record"));
-	cfg.add_u32("map_kills_" + map, this.get_u32("map_kill_record"));
-	cfg.add_u32("global_kills", this.get_u32("global_kill_record"));
-	cfg.saveFile(records_file);
+        cfg.add_u16("global", this.get_u16("global_record"));
+        cfg.add_u32("map_kills_" + map, this.get_u32("map_kill_record"));
+        cfg.add_u32("global_kills", this.get_u32("global_kill_record"));
+        cfg.saveFile(records_file_name);
 }
 
 void onTick(CRules @ this)


### PR DESCRIPTION
## Summary
- Separate record file name and path to avoid security errors
- Load from Cache directory but save using file name only, matching openStatsConfig approach

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a7603cf55883338adb729ab8eeb154