### PR TITLE
Fix builder animation crash and add missing scripts

### DIFF
--- a/Entities/Classes/SurvivorBuilder/BuilderAnim.as
+++ b/Entities/Classes/SurvivorBuilder/BuilderAnim.as
@@ -1,0 +1,52 @@
+#include "RunnerCommon.as"
+
+void onInit(CSprite@ this)
+{
+    // Prevent running while blob is in fire to match standard behaviour
+    this.getCurrentScript().runFlags |= Script::tick_not_infire;
+}
+
+void onTick(CSprite@ this)
+{
+    CBlob@ blob = this.getBlob();
+    if (blob is null)
+    {
+        return; // safety check
+    }
+
+    if (blob.hasTag("dead"))
+    {
+        if (!this.isAnimation("dead"))
+        {
+            this.SetAnimation("dead");
+        }
+        return;
+    }
+
+    const bool left = blob.isKeyPressed(key_left);
+    const bool right = blob.isKeyPressed(key_right);
+    const bool up = blob.isKeyPressed(key_up);
+    const bool down = blob.isKeyPressed(key_down);
+    const bool inair = (!blob.isOnGround() && !blob.isOnLadder());
+
+    if (blob.hasTag("seated"))
+    {
+        this.SetAnimation("crouch");
+    }
+    else if (blob.isKeyPressed(key_action1) || (this.isAnimation("build") && !this.isAnimationEnded()))
+    {
+        this.SetAnimation("build");
+    }
+    else if (inair)
+    {
+        this.SetAnimation("fall");
+    }
+    else if ((left || right) || (blob.isOnLadder() && (up || down)))
+    {
+        this.SetAnimation("run");
+    }
+    else
+    {
+        this.SetAnimation("default");
+    }
+}

--- a/Entities/Items/Activatable.as
+++ b/Entities/Items/Activatable.as
@@ -1,0 +1,5 @@
+// Marks a blob as activatable so it can be triggered by player interaction.
+void onInit(CBlob@ this)
+{
+    this.Tag("activatable");
+}

--- a/Entities/Items/WoodenHit.as
+++ b/Entities/Items/WoodenHit.as
@@ -1,0 +1,5 @@
+// Simple placeholder for wooden hit sound or behaviour.
+void onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitter, u8 customData)
+{
+    // Intentionally left blank - placeholder implementation
+}

--- a/registration.json
+++ b/registration.json
@@ -1,0 +1,6 @@
+{
+  "name": "ZombieGarden",
+  "version": "1.0.0",
+  "description": "Community Zombie Garden mod",
+  "author": "Unknown"
+}


### PR DESCRIPTION
## Summary
- add builder animation script with null checks
- add placeholder Activatable and WoodenHit scripts
- include registration file and remove placeholder icon assets

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68a7c8b162ec8333a07c96392d1e532f