### PR TITLE
Ensure difficulty scales from day one

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -159,8 +159,9 @@ class ZombiesCore : RulesCore
 			}
 		}
 
-		// final difficulty (apply cap after any bonus change)
-		float difficulty = dayNumber * 0.5f;
+                // final difficulty (apply cap after any bonus change)
+                // add a base value so negative modifiers don't stall early scaling
+                float difficulty = 1.0f + dayNumber * 0.5f;
 		difficulty += pillars * 0.2f;	  // pillars add pressure
 		difficulty -= altars * 0.2f;	  // altars ease the round
 		difficulty += survivors * 0.05f;  // more survivors harden the waves


### PR DESCRIPTION
## Summary
- start day difficulty at a base value so early negative modifiers don't stall scaling

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68a7d18e2da48333b11842366df461cc