### PR TITLE
Fix early-round difficulty scaling with altar offset

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Config.as
+++ b/Rules/Scripts/Zombies/Zombies_Config.as
@@ -14,9 +14,9 @@ void Config(ZombiesCore @ this)
 
 	// round-specific bookkeeping so values don't persist between rounds
 	this.rules.set_f32("difficulty_bonus", 0.0f);
-	this.rules.set_s32("last_wipe_day", -1);
-	this.rules.set_s32("days_offset", 0);
-	this.rules.set_f32("difficulty", 0.0f);
+       this.rules.set_s32("last_wipe_day", -1);
+       this.rules.set_s32("days_offset", 0);
+       this.rules.set_f32("difficulty", 0.1f);
 
 	// ----------------------------
 	// Mob limits (hard caps)

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -44,8 +44,8 @@ class ZombiesCore : RulesCore
 		// seed counters once (single source of truth)
 		RefreshMobCountsToRules();
 
-		// seed initial difficulty value
-		rules.set_f32("difficulty", 0.25f);
+               // seed initial difficulty value
+               rules.set_f32("difficulty", 0.1f);
 	}
 
         void Update()
@@ -165,20 +165,21 @@ class ZombiesCore : RulesCore
 			}
 		}
 
-		// final difficulty (apply cap after any bonus change)
-		// add a base value so negative modifiers don't stall early scaling
-		float difficulty = dayNumber * 0.5f;
-		difficulty += pillars * 0.2f;	  // pillars add pressure
-		difficulty -= altars * 0.2f;	  // altars ease the round
-		difficulty += survivors * 0.05f;  // more survivors harden the waves
-		difficulty -= undead * 0.2f;	  // undead players make it tougher
-		difficulty += days_offset * 0.1f; // manual day skips ups difficulty
-		difficulty += wipeBonus;
-		if (difficulty < 0.0f)
-			difficulty = 0.0f;
-		if (difficulty > 20.0f)
-			difficulty = 20.0f; // expanded cap
-		rules.set_f32("difficulty", difficulty);
+                // final difficulty (apply cap after any bonus change)
+                // baseline grows by 0.1 every day so altars can't stall scaling
+                const float baseDifficulty = dayNumber * 0.1f;
+                float difficulty = dayNumber * 0.5f;
+                difficulty += pillars * 0.2f;     // pillars add pressure
+                difficulty -= altars * 0.2f;      // altars ease the round
+                difficulty += survivors * 0.05f;  // more survivors harden the waves
+                difficulty -= undead * 0.2f;      // undead players make it tougher
+                difficulty += days_offset * 0.1f; // manual day skips ups difficulty
+                difficulty += wipeBonus;
+                if (difficulty < baseDifficulty)
+                        difficulty = baseDifficulty;
+                if (difficulty > 20.0f)
+                        difficulty = 20.0f; // expanded cap
+                rules.set_f32("difficulty", difficulty);
 
 		int spawnRate = 90 - int(difficulty * 3);
 		if (spawnRate < 15)


### PR DESCRIPTION
## Summary
- Ensure difficulty starts at 0.1 each round
- Clamp daily difficulty to increase by at least 0.1 even with many altars

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7d7510a308333b630c2729685b4bd