### PR TITLE
Load default GUI on startup

### DIFF
--- a/Rules/Scripts/Zombies/Zombies_Interface.as
+++ b/Rules/Scripts/Zombies/Zombies_Interface.as
@@ -1,5 +1,6 @@
 #include "Core/Structs.as"
 #include "GlobalPopup.as"
+#include "Scripts/Default/DefaultGUI.as"
 
 // -------------------------------------
 //  Interface / HUD rendering
@@ -78,7 +79,14 @@ int CountTeamPlayers(const int teamNum)
 // -------------------------------------
 void onInit(CRules @ this)
 {
-	// nothing needed here (kept for symmetry)
+        // Load default GUI assets so icons and tokens are available
+        LoadDefaultGUI();
+}
+
+void onRestart(CRules @ this)
+{
+        // Ensure GUI assets are reloaded on map restart
+        LoadDefaultGUI();
 }
 
 void onRender(CRules @ this)


### PR DESCRIPTION
## Summary
- Load default GUI assets when rules initialize
- Reload GUI assets on map restart to keep HUD icons available

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*

------
https://chatgpt.com/codex/tasks/task_e_68a81a8659ac8333929ff8a97730f970