### PR TITLE
Fix grass mining and ore break stage tiles

### DIFF
--- a/Scripts/MapLoaders/LoaderUtilities.as
+++ b/Scripts/MapLoaders/LoaderUtilities.as
@@ -16,11 +16,11 @@ bool onMapTileCollapse(CMap @map, u32 offset)
 			blob.server_Die();
 		}
 	}
-	if ((map.getTile(offset).type > 260 && map.getTile(offset).type < 267) || (map.getTile(offset).type > 276 && map.getTile(offset).type < 400))
-	{
-		return false;
-	}
-	return true;
+        if (map.getTile(offset).type > 260 && map.getTile(offset).type < 267)
+        {
+                return false;
+        }
+        return true;
 }
 
 TileType server_onTileHit(CMap @map, f32 damage, u32 index, TileType oldTileType)
@@ -174,46 +174,48 @@ TileType server_onTileHit(CMap @map, f32 damage, u32 index, TileType oldTileType
 			}
 
 			// Coal Ore
-			case CMap::tile_coalore:
-			{
-				OnCoalTileHit(map, index);
-				return CMap::tile_coalore_d0;
-			}
-			case CMap::tile_coalore_d0:
-			case CMap::tile_coalore_d1:
-			case CMap::tile_coalore_d2:
-			case CMap::tile_coalore_d3:
-			case CMap::tile_coalore_d4:
-			{
-				OnCoalTileHit(map, index);
-				return oldTileType + 1;
-			}
-			case CMap::tile_coalore_d5:
-			{
-				OnCoalTileDestroyed(map, index);
-				return CMap::tile_ground_back;
-			}
+                        case CMap::tile_coalore:
+                        {
+                                OnCoalTileHit(map, index);
+                                return CMap::tile_coalore_d0;
+                        }
+                        case CMap::tile_coalore_d0:
+                        case CMap::tile_coalore_d1:
+                        case CMap::tile_coalore_d2:
+                        case CMap::tile_coalore_d3:
+                        case CMap::tile_coalore_d4:
+                        case CMap::tile_coalore_d5:
+                        {
+                                OnCoalTileHit(map, index);
+                                return oldTileType + 1;
+                        }
+                        case CMap::tile_coalore_d6:
+                        {
+                                OnCoalTileDestroyed(map, index);
+                                return CMap::tile_ground_back;
+                        }
 
 			// Copper Ore
-			case CMap::tile_copperore:
-			{
-				OnCopperTileHit(map, index);
-				return CMap::tile_copperore_d0;
-			}
-			case CMap::tile_copperore_d0:
-			case CMap::tile_copperore_d1:
-			case CMap::tile_copperore_d2:
-			case CMap::tile_copperore_d3:
-			case CMap::tile_copperore_d4:
-			{
-				OnCopperTileHit(map, index);
-				return oldTileType + 1;
-			}
-			case CMap::tile_copperore_d5:
-			{
-				OnCopperTileDestroyed(map, index);
-				return CMap::tile_ground_back;
-			}
+                        case CMap::tile_copperore:
+                        {
+                                OnCopperTileHit(map, index);
+                                return CMap::tile_copperore_d0;
+                        }
+                        case CMap::tile_copperore_d0:
+                        case CMap::tile_copperore_d1:
+                        case CMap::tile_copperore_d2:
+                        case CMap::tile_copperore_d3:
+                        case CMap::tile_copperore_d4:
+                        case CMap::tile_copperore_d5:
+                        {
+                                OnCopperTileHit(map, index);
+                                return oldTileType + 1;
+                        }
+                        case CMap::tile_copperore_d6:
+                        {
+                                OnCopperTileDestroyed(map, index);
+                                return CMap::tile_ground_back;
+                        }
 
 			// BLOOD DIRT
 			case CMap::tile_littlebloodground:
@@ -453,34 +455,36 @@ void onSetTile(CMap @map, u32 index, TileType tile_new, TileType tile_old)
 			}
 
 			// coal ore
-			case CMap::tile_coalore:
-			case CMap::tile_coalore_d0:
-			case CMap::tile_coalore_d1:
-			case CMap::tile_coalore_d2:
-			case CMap::tile_coalore_d3:
-			case CMap::tile_coalore_d4:
-			case CMap::tile_coalore_d5:
-			{
-				OnCoalTileHit(map, index);
-				map.RemoveTileFlag(index, Tile::LIGHT_PASSES | Tile::LIGHT_SOURCE);
-				map.AddTileFlag(index, Tile::SOLID | Tile::COLLISION);
-				break;
-			}
+                        case CMap::tile_coalore:
+                        case CMap::tile_coalore_d0:
+                        case CMap::tile_coalore_d1:
+                        case CMap::tile_coalore_d2:
+                        case CMap::tile_coalore_d3:
+                        case CMap::tile_coalore_d4:
+                        case CMap::tile_coalore_d5:
+                        case CMap::tile_coalore_d6:
+                        {
+                                OnCoalTileHit(map, index);
+                                map.RemoveTileFlag(index, Tile::LIGHT_PASSES | Tile::LIGHT_SOURCE);
+                                map.AddTileFlag(index, Tile::SOLID | Tile::COLLISION);
+                                break;
+                        }
 
 			// copper ore
-			case CMap::tile_copperore:
-			case CMap::tile_copperore_d0:
-			case CMap::tile_copperore_d1:
-			case CMap::tile_copperore_d2:
-			case CMap::tile_copperore_d3:
-			case CMap::tile_copperore_d4:
-			case CMap::tile_copperore_d5:
-			{
-				OnCopperTileHit(map, index);
-				map.RemoveTileFlag(index, Tile::LIGHT_PASSES | Tile::LIGHT_SOURCE);
-				map.AddTileFlag(index, Tile::SOLID | Tile::COLLISION);
-				break;
-			}
+                        case CMap::tile_copperore:
+                        case CMap::tile_copperore_d0:
+                        case CMap::tile_copperore_d1:
+                        case CMap::tile_copperore_d2:
+                        case CMap::tile_copperore_d3:
+                        case CMap::tile_copperore_d4:
+                        case CMap::tile_copperore_d5:
+                        case CMap::tile_copperore_d6:
+                        {
+                                OnCopperTileHit(map, index);
+                                map.RemoveTileFlag(index, Tile::LIGHT_PASSES | Tile::LIGHT_SOURCE);
+                                map.AddTileFlag(index, Tile::SOLID | Tile::COLLISION);
+                                break;
+                        }
 
 			// blood ground
 			case CMap::tile_littlebloodground:


### PR DESCRIPTION
## Summary
- Allow custom grass tiles to collapse so builders can mine them
- Include final damage frame for coal and copper ore tiles
- Keep ore tiles solid through all damage stages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a81ed8c2908333ae15ee2b69d978cc