### PR TITLE
Make custom bloodgrass tiles minable

### DIFF
--- a/Scripts/MapLoaders/CustomBlocks.as
+++ b/Scripts/MapLoaders/CustomBlocks.as
@@ -183,10 +183,11 @@ void HandleCustomTile(CMap @map, int offset, SColor pixel)
 			map.AddTileFlag(offset, Tile::SOLID | Tile::COLLISION);
 			break;
 
-		case custom_colors::color_bloodgrass:
-			map.SetTile(offset, CMap::tile_mediumbloodgrass);
-			map.RemoveTileFlag(offset, Tile::SOLID | Tile::COLLISION);
-			map.AddTileFlag(offset, Tile::BACKGROUND | Tile::LIGHT_SOURCE | Tile::LIGHT_PASSES | Tile::WATER_PASSES);
-			break;
-	}
+               case custom_colors::color_bloodgrass:
+                       // place solid blood grass ground so it can be mined
+                       map.SetTile(offset, CMap::tile_mediumbloodgrassground);
+                       map.RemoveTileFlag(offset, Tile::LIGHT_SOURCE | Tile::LIGHT_PASSES);
+                       map.AddTileFlag(offset, Tile::SOLID | Tile::COLLISION);
+                       break;
+       }
 }

--- a/Scripts/MapLoaders/LoaderUtilities.as
+++ b/Scripts/MapLoaders/LoaderUtilities.as
@@ -7,19 +7,28 @@
 
 bool onMapTileCollapse(CMap @map, u32 offset)
 {
-	if (isDummyTile(map.getTile(offset).type))
-	{
-		CBlob @blob = getBlobByNetworkID(server_getDummyGridNetworkID(offset));
-		if (blob !is null)
-		{
-			blob.server_Die();
-		}
-	}
-	if (map.getTile(offset).type > 260 && map.getTile(offset).type < 267)
-	{
-		return false;
-	}
-	return true;
+       TileType type = map.getTile(offset).type;
+
+       // only handle custom tiles here; let vanilla tiles collapse normally
+       if (type <= 255)
+       {
+               return true;
+       }
+
+       if (isDummyTile(type))
+       {
+               CBlob @blob = getBlobByNetworkID(server_getDummyGridNetworkID(offset));
+               if (blob !is null)
+               {
+                       blob.server_Die();
+               }
+       }
+
+       if (type > 260 && type < 267)
+       {
+               return false;
+       }
+       return true;
 }
 
 TileType server_onTileHit(CMap @map, f32 damage, u32 index, TileType oldTileType)


### PR DESCRIPTION
## Summary
- Map blood grass color to solid ground tile so it can be mined
- Handle tile collapse only for custom tiles

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a8d023f8708333980d4da4bcdc7575