### PR TITLE
Fix drill resource drop and network teleport abilities

### DIFF
--- a/Entities/Classes/SurvivorWizard/SummonFamiliar.as
+++ b/Entities/Classes/SurvivorWizard/SummonFamiliar.as
@@ -2,8 +2,9 @@
 
 void onInit(CBlob @ this)
 {
-	this.set_u32("last teleport", 0);
-	this.set_bool("teleport ready", true);
+        this.set_u32("last teleport", 0);
+        this.set_bool("teleport ready", true);
+        this.addCommandID("teleport");
 }
 
 void onTick(CBlob @ this)
@@ -18,9 +19,11 @@ void onTick(CBlob @ this)
 			Vec2f delta = this.getPosition() - this.getAimPos();
 			if (delta.Length() < TELEPORT_DISTANCE)
 			{
-				this.set_u32("last teleport", gametime);
-				this.set_bool("teleport ready", false);
-				SummonElemental(this, this.getAimPos());
+                                this.set_u32("last teleport", gametime);
+                                this.set_bool("teleport ready", false);
+                                CBitStream params;
+                                params.write_Vec2f(this.getAimPos());
+                                this.SendCommand(this.getCommandID("teleport"), params);
 			}
 			else if (this.isMyPlayer())
 			{
@@ -44,6 +47,15 @@ void onTick(CBlob @ this)
 			this.getSprite().PlaySound("/Cooldown1.ogg");
 		}
 	}
+}
+
+void onCommand(CBlob @ this, u8 cmd, CBitStream @params)
+{
+        if (cmd == this.getCommandID("teleport"))
+        {
+                Vec2f aimpos = params.read_Vec2f();
+                SummonElemental(this, aimpos);
+        }
 }
 
 void SummonElemental(CBlob @ this, Vec2f aimpos)

--- a/Entities/Items/BlessedDrill/BlessedDrill.as
+++ b/Entities/Items/BlessedDrill/BlessedDrill.as
@@ -330,12 +330,6 @@ f32 onHit(CBlob @ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob @hit
 
 	return damage;
 }
-
-void onHitMap(CBlob @ this, Vec2f worldPoint, Vec2f velocity, f32 damage, u8 customData)
-{
-	getMap().server_DestroyTile(worldPoint, damage, this);
-}
-
 void onAttach(CBlob @ this, CBlob @attached, AttachmentPoint @attachedPoint)
 {
 	this.getCurrentScript().runFlags &= ~Script::tick_not_sleeping;


### PR DESCRIPTION
## Summary
- Allow the Blessed Drill to generate resources by removing redundant map destruction
- Make wizard and undead mystic abilities send commands so teleport/force push trigger on server
- Remove steel drill implementation per review feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f19f40088333993ef780437ba209