### PR TITLE
Fix cast crash when loading Undead Builder inventory

### DIFF
--- a/Entities/Classes/UndeadBuilder/UndeadBuilderInventory.as
+++ b/Entities/Classes/UndeadBuilder/UndeadBuilderInventory.as
@@ -36,6 +36,20 @@ const u8 GRID_PADDING = 12;
 Vec2f MENU_SIZE(3, 5);
 const u32 SHOW_NO_BUILD_TIME = 90;
 
+// This script is used by both the builder's inventory and sprite.
+// When it's loaded as a sprite script the engine still calls an
+// `onInit` callback which expects a `CSprite@` parameter.  The original
+// inventory-only implementation didn't provide such a handler which led
+// the engine to attempt casting the sprite to a `CInventory@` instead,
+// spamming the console with InvalidCastException errors as soon as the
+// class was initialised.  Providing this no-op overload ensures the
+// correct function is invoked for each component type.
+void onInit(CSprite @this)
+{
+    // Intentionally left blank – required so the script can be safely
+    // attached as a sprite script without causing cast exceptions.
+}
+
 void onInit(CInventory @ this)
 {
 	CBlob @blob = this.getBlob();


### PR DESCRIPTION
## Summary
- prevent InvalidCastException spam when spawning as an Undead Builder by adding a sprite-specific `onInit` handler

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a8f9660f388333b5c14a9f2c5c8012