### PR TITLE
Fix wizard and mystic teleport ability

### DIFF
--- a/Entities/Classes/SurvivorWizard/SummonFamiliar.as
+++ b/Entities/Classes/SurvivorWizard/SummonFamiliar.as
@@ -14,22 +14,22 @@ void onTick(CBlob @ this)
 
 	if (ready)
 	{
-		if (this.isKeyJustPressed(key_action2))
-		{
-			Vec2f delta = this.getPosition() - this.getAimPos();
-			if (delta.Length() < TELEPORT_DISTANCE)
-			{
+                if (this.isKeyJustPressed(key_action2))
+                {
+                        Vec2f delta = this.getPosition() - this.getAimPos();
+                        if (delta.Length() < TELEPORT_DISTANCE)
+                        {
                                 this.set_u32("last teleport", gametime);
                                 this.set_bool("teleport ready", false);
                                 CBitStream params;
                                 params.write_Vec2f(this.getAimPos());
                                 this.SendCommand(this.getCommandID("teleport"), params);
-			}
-			else if (this.isMyPlayer())
-			{
-				Sound::Play("option.ogg");
-			}
-		}
+                        }
+                        else if (this.isMyPlayer())
+                        {
+                                Sound::Play("option.ogg");
+                        }
+                }
 	}
 	else
 	{
@@ -60,23 +60,24 @@ void onCommand(CBlob @ this, u8 cmd, CBitStream @params)
 
 void SummonElemental(CBlob @ this, Vec2f aimpos)
 {
-	CBlob @[] raven_blobs;
-	getBlobsByName("raven", @raven_blobs);
-	u8 num_raven = raven_blobs.length;
+        ParticleAnimated("MagicSmoke.png", this.getPosition(), Vec2f(0, 0), 0.0f, 1.0f, 1.5, -0.1f, false);
+        this.getSprite().PlaySound("Thunder2.ogg");
 
-	if (getNet().isServer())
-	{
-		if (num_raven < 1)
-		{
-			server_CreateBlob("raven", 0, this.getPosition());
-		}
-	}
+        if (getNet().isServer())
+        {
+                CBlob @[] raven_blobs;
+                getBlobsByName("raven", @raven_blobs);
+                u8 num_raven = raven_blobs.length;
 
-	// whoosh, teleport us
-	ParticleAnimated("MagicSmoke.png", this.getPosition(), Vec2f(0, 0), 0.0f, 1.0f, 1.5, -0.1f, false);
-	this.getSprite().PlaySound("Thunder2.ogg");
-	this.setPosition(aimpos);
-	this.setVelocity(Vec2f_zero);
-	ParticleAnimated("MagicSmoke.png", this.getPosition(), Vec2f(0, 0), 0.0f, 1.0f, 1.5, -0.1f, false);
-	this.getSprite().PlaySound("/Respawn.ogg");
+                if (num_raven < 1)
+                {
+                        server_CreateBlob("raven", 0, this.getPosition());
+                }
+
+                this.setPosition(aimpos);
+                this.setVelocity(Vec2f_zero);
+        }
+
+        ParticleAnimated("MagicSmoke.png", aimpos, Vec2f(0, 0), 0.0f, 1.0f, 1.5, -0.1f, false);
+        this.getSprite().PlaySound("/Respawn.ogg");
 }

--- a/Entities/Classes/UndeadMystic/ForcePush.as
+++ b/Entities/Classes/UndeadMystic/ForcePush.as
@@ -17,22 +17,22 @@ void onTick(CBlob @ this)
 
 	if (ready)
 	{
-		if (this.isKeyJustPressed(key_action2))
-		{
-			Vec2f delta = this.getPosition() - this.getAimPos();
-			if (delta.Length() < TELEPORT_DISTANCE)
-			{
+                if (this.isKeyJustPressed(key_action2))
+                {
+                        Vec2f delta = this.getPosition() - this.getAimPos();
+                        if (delta.Length() < TELEPORT_DISTANCE)
+                        {
                                 this.set_u32("last teleport", gametime);
                                 this.set_bool("teleport ready", false);
                                 CBitStream params;
                                 params.write_Vec2f(this.getAimPos());
                                 this.SendCommand(this.getCommandID("force push"), params);
-			}
-			else if (this.isMyPlayer())
-			{
-				Sound::Play("option.ogg");
-			}
-		}
+                        }
+                        else if (this.isMyPlayer())
+                        {
+                                Sound::Play("option.ogg");
+                        }
+                }
 	}
 	else
 	{
@@ -65,11 +65,11 @@ void ForcePush(CBlob @blob, Vec2f aimpos)
 {
         CMap @map = blob.getMap();
 
-        CBlob @[] blobs;
-        map.getBlobsInRadius(aimpos, 25.0f, @blobs);
-
         if (getNet().isServer())
         {
+                CBlob @[] blobs;
+                map.getBlobsInRadius(aimpos, 25.0f, @blobs);
+
                 for (uint i = 0; i < blobs.length; i++)
                 {
                         CBlob @pushed_blob = blobs[i];


### PR DESCRIPTION
## Summary
- Run wizard teleport through a `teleport` command that applies server-side and still shows client effects
- Trigger mystic force push using a server-validated command while keeping knockback effects synchronized

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a8faf7748c8333bd2c9dfb96d45e6f