### PR TITLE
Add grab cooldown for gregs and gargoyles

### DIFF
--- a/Entities/Zombies/Greg/Greg.as
+++ b/Entities/Zombies/Greg/Greg.as
@@ -3,6 +3,8 @@
 #include "CreatureCommon.as";
 
 const int COINS_ON_DEATH = 25;
+const s16 GRAB_TIME = 120;
+const s16 GRAB_COOLDOWN = 60;
 
 void onInit(CBlob @ this)
 {
@@ -27,14 +29,17 @@ void onInit(CBlob @ this)
 
 	this.getBrain().server_SetActive(true);
 
-	this.set_f32("gib health", 0.0f);
-	this.Tag("flesh");
-	this.Tag("zombie");
-	this.Tag("enemy");
-	this.Tag("gregs");
+       this.set_f32("gib health", 0.0f);
+       this.Tag("flesh");
+       this.Tag("zombie");
+       this.Tag("enemy");
+       this.Tag("gregs");
+       this.set_s16("grab timer", 0);
+       this.set_s16("grab cooldown", 0);
+       this.set_bool("was attached", false);
 
-	this.getCurrentScript().runFlags |= Script::tick_not_attached;
-	this.getCurrentScript().removeIfTag = "dead";
+       this.getCurrentScript().runFlags |= Script::tick_not_attached;
+       this.getCurrentScript().removeIfTag = "dead";
 }
 
 void onCollision(CBlob @ this, CBlob @blob, bool solid, Vec2f normal, Vec2f point1)
@@ -55,10 +60,45 @@ void onCollision(CBlob @ this, CBlob @blob, bool solid, Vec2f normal, Vec2f poin
 	if (brain is null)
 		return;
 
-	if (blob is brain.getTarget())
-	{
-		this.server_AttachTo(blob, "PICKUP");
-	}
+       if (blob is brain.getTarget() && !this.hasAttached() && this.get_s16("grab cooldown") <= 0)
+       {
+               this.server_AttachTo(blob, "PICKUP");
+       }
+}
+
+void onTick(CBlob @ this)
+{
+       bool attached = this.hasAttached();
+       bool wasAttached = this.get_bool("was attached");
+
+       if (attached)
+       {
+               s16 grabTimer = this.get_s16("grab timer") + 1;
+               if (grabTimer > GRAB_TIME)
+               {
+                       this.server_DetachAll();
+                       attached = false;
+                       this.set_s16("grab cooldown", GRAB_COOLDOWN);
+                       grabTimer = 0;
+               }
+               this.set_s16("grab timer", grabTimer);
+       }
+       else
+       {
+               this.set_s16("grab timer", 0);
+               s16 cooldown = this.get_s16("grab cooldown");
+               if (cooldown > 0)
+               {
+                       this.set_s16("grab cooldown", cooldown - 1);
+               }
+       }
+
+       if (!attached && wasAttached)
+       {
+               this.set_s16("grab cooldown", GRAB_COOLDOWN);
+       }
+
+       this.set_bool("was attached", attached);
 }
 
 f32 onHit(CBlob @ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob @hitterBlob, u8 customData)

--- a/Entities/Zombies/Greg/Greg2.as
+++ b/Entities/Zombies/Greg/Greg2.as
@@ -3,6 +3,8 @@
 #include "CreatureCommon.as";
 
 const int COINS_ON_DEATH = 25;
+const s16 GRAB_TIME = 120;
+const s16 GRAB_COOLDOWN = 60;
 
 void onInit(CBlob @ this)
 {
@@ -27,14 +29,17 @@ void onInit(CBlob @ this)
 
 	this.getBrain().server_SetActive(true);
 
-	this.set_f32("gib health", 0.0f);
-	this.Tag("flesh");
-	this.Tag("zombie");
-	this.Tag("enemy");
-	this.Tag("gregs");
+       this.set_f32("gib health", 0.0f);
+       this.Tag("flesh");
+       this.Tag("zombie");
+       this.Tag("enemy");
+       this.Tag("gregs");
+       this.set_s16("grab timer", 0);
+       this.set_s16("grab cooldown", 0);
+       this.set_bool("was attached", false);
 
-	this.getCurrentScript().runFlags |= Script::tick_not_attached;
-	this.getCurrentScript().removeIfTag = "dead";
+       this.getCurrentScript().runFlags |= Script::tick_not_attached;
+       this.getCurrentScript().removeIfTag = "dead";
 }
 
 void onCollision(CBlob @ this, CBlob @blob, bool solid, Vec2f normal, Vec2f point1)
@@ -55,10 +60,45 @@ void onCollision(CBlob @ this, CBlob @blob, bool solid, Vec2f normal, Vec2f poin
 	if (brain is null)
 		return;
 
-	if (blob is brain.getTarget())
-	{
-		this.server_AttachTo(blob, "PICKUP");
-	}
+       if (blob is brain.getTarget() && !this.hasAttached() && this.get_s16("grab cooldown") <= 0)
+       {
+               this.server_AttachTo(blob, "PICKUP");
+       }
+}
+
+void onTick(CBlob @ this)
+{
+       bool attached = this.hasAttached();
+       bool wasAttached = this.get_bool("was attached");
+
+       if (attached)
+       {
+               s16 grabTimer = this.get_s16("grab timer") + 1;
+               if (grabTimer > GRAB_TIME)
+               {
+                       this.server_DetachAll();
+                       attached = false;
+                       this.set_s16("grab cooldown", GRAB_COOLDOWN);
+                       grabTimer = 0;
+               }
+               this.set_s16("grab timer", grabTimer);
+       }
+       else
+       {
+               this.set_s16("grab timer", 0);
+               s16 cooldown = this.get_s16("grab cooldown");
+               if (cooldown > 0)
+               {
+                       this.set_s16("grab cooldown", cooldown - 1);
+               }
+       }
+
+       if (!attached && wasAttached)
+       {
+               this.set_s16("grab cooldown", GRAB_COOLDOWN);
+       }
+
+       this.set_bool("was attached", attached);
 }
 
 f32 onHit(CBlob @ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob @hitterBlob, u8 customData)


### PR DESCRIPTION
## Summary
- Limit Greg and Gargoyle grabs to 120 ticks and add 60 tick cooldown before they can grab again
- Track grab timers and cooldowns to enforce detach and re-grab timing

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a900f52c188333bd1ba092f260be74