### PR TITLE
Ensure global popup values sync to clients

### DIFF
--- a/Entities/Items/Scrolls/2Weeks/Scroll2Weeks.as
+++ b/Entities/Items/Scrolls/2Weeks/Scroll2Weeks.as
@@ -26,9 +26,10 @@ void onCommand(CBlob @ this, u8 cmd, CBitStream @params)
 		{
 			if (getNet().isServer())
 			{
-				getRules().add_s32("days_offset", 14);
-				getMap().SetDayTime(0.5);
-				hit = true;
+getRules().add_s32("days_offset", 14);
+getRules().Sync("days_offset", true);
+getMap().SetDayTime(0.5);
+hit = true;
 			}
 		}
 

--- a/Rules/Scripts/Utilities/ChatCommands.as
+++ b/Rules/Scripts/Utilities/ChatCommands.as
@@ -106,10 +106,12 @@ bool onServerProcessChat(CRules @ this, const string& in text_in, string& out te
 				int day_cycle = getRules().daycycle_speed * 60;
 				int gamestart = getRules().get_s32("gamestart");
 				int dayNumber = ((getGameTime() - gamestart) / getTicksASecond() / day_cycle) + 1;
-				int extra = (time - dayNumber) * day_cycle * getTicksASecond();
-				getRules().set_s32("gamestart", gamestart - extra);
-				getMap().SetDayTime(time);
-				getRules().set_bool("dayCheated", true);
+int extra = (time - dayNumber) * day_cycle * getTicksASecond();
+getRules().set_s32("gamestart", gamestart - extra);
+getRules().Sync("gamestart", true);
+getMap().SetDayTime(time);
+getRules().set_bool("dayCheated", true);
+getRules().Sync("dayCheated", true);
 			}
 		}
 	}

--- a/Rules/Scripts/Utilities/GlobalPopup.as
+++ b/Rules/Scripts/Utilities/GlobalPopup.as
@@ -50,13 +50,14 @@ void Server_GlobalPopup(CRules @rules,
 	rules.set_u32(POP_COLOR_HEAD_KEY, PackColor(bodyCol)); // same as body for normal
 	rules.set_u32(POP_COLOR_BODY_KEY, PackColor(bodyCol));
 
-	// Broadcast to all clients (public sync = false)
-	rules.Sync(POP_MSG_KEY, false);
-	rules.Sync(POP_START_KEY, false);
-	rules.Sync(POP_DURATION_KEY, false);
-	rules.Sync(POP_KIND_KEY, false);
-	rules.Sync(POP_COLOR_HEAD_KEY, false);
-	rules.Sync(POP_COLOR_BODY_KEY, false);
+        // Broadcast to all clients
+        // 2nd parameter "true" ensures the value is synced publicly
+        rules.Sync(POP_MSG_KEY, true);
+        rules.Sync(POP_START_KEY, true);
+        rules.Sync(POP_DURATION_KEY, true);
+        rules.Sync(POP_KIND_KEY, true);
+        rules.Sync(POP_COLOR_HEAD_KEY, true);
+        rules.Sync(POP_COLOR_BODY_KEY, true);
 }
 
 // ----------------------------------
@@ -80,12 +81,13 @@ void Server_BossPopup(CRules @rules,
 	rules.set_u32(POP_COLOR_HEAD_KEY, PackColor(headlineCol));
 	rules.set_u32(POP_COLOR_BODY_KEY, PackColor(bodyCol));
 
-	rules.Sync(POP_MSG_KEY, false);
-	rules.Sync(POP_START_KEY, false);
-	rules.Sync(POP_DURATION_KEY, false);
-	rules.Sync(POP_KIND_KEY, false);
-	rules.Sync(POP_COLOR_HEAD_KEY, false);
-	rules.Sync(POP_COLOR_BODY_KEY, false);
+        // Ensure clients receive all popup parameters
+        rules.Sync(POP_MSG_KEY, true);
+        rules.Sync(POP_START_KEY, true);
+        rules.Sync(POP_DURATION_KEY, true);
+        rules.Sync(POP_KIND_KEY, true);
+        rules.Sync(POP_COLOR_HEAD_KEY, true);
+        rules.Sync(POP_COLOR_BODY_KEY, true);
 }
 
 // Optional compatibility shim

--- a/Rules/Scripts/Zombies/Zombies_Config.as
+++ b/Rules/Scripts/Zombies/Zombies_Config.as
@@ -10,14 +10,20 @@ void Config(ZombiesCore @ this)
 	// ============================
 
 	// How long a dead player waits before they can respawn (seconds)
-	this.spawnTime = 0.2f;
-	this.rules.set_f32("spawn_time", this.spawnTime);
+this.spawnTime = 0.2f;
+this.rules.set_f32("spawn_time", this.spawnTime);
+this.rules.Sync("spawn_time", true);
 
 	// round-specific bookkeeping so values don't persist between rounds
-	this.rules.set_f32("difficulty_bonus", 0.0f);
-	this.rules.set_s32("last_wipe_day", -1);
-	this.rules.set_s32("days_offset", 0);
-	this.rules.set_f32("difficulty", 0.1f);
+this.rules.set_f32("difficulty_bonus", 0.0f);
+this.rules.set_s32("last_wipe_day", -1);
+this.rules.set_s32("days_offset", 0);
+this.rules.set_f32("difficulty", 0.1f);
+
+this.rules.Sync("difficulty_bonus", true);
+this.rules.Sync("last_wipe_day", true);
+this.rules.Sync("days_offset", true);
+this.rules.Sync("difficulty", true);
 
 	// ----------------------------
 	// Mob limits (hard caps)
@@ -33,22 +39,39 @@ void Config(ZombiesCore @ this)
 	this.rules.set_s32("max_bison", 8);
 	this.rules.set_s32("max_banshees", 6);
 	this.rules.set_s32("max_horror", 8);
-	this.rules.set_s32("max_gasbags", 10);
+this.rules.set_s32("max_gasbags", 10);
 
-	// ----------------------------
+this.rules.Sync("max_zombies", true);
+this.rules.Sync("max_pzombies", true);
+this.rules.Sync("max_migrantbots", true);
+this.rules.Sync("max_wraiths", true);
+this.rules.Sync("max_gregs", true);
+this.rules.Sync("max_imol", true);
+this.rules.Sync("max_digger", true);
+this.rules.Sync("max_bison", true);
+this.rules.Sync("max_banshees", true);
+this.rules.Sync("max_horror", true);
+this.rules.Sync("max_gasbags", true);
+
+// ----------------------------
 	// Win/Loss pacing
 	// ----------------------------
 	this.rules.set_s32("days_to_survive", 0);                         // <= 0 means endless
 	this.rules.set_s32("curse_day", 250);				  // night(s) from which survivors can auto-zombify
 	this.rules.set_s32("hardmode_day", 100);			  // the day zombies can spawn during the day
 	this.rules.set_bool("ruins_portal_active", false);		  // ruins become portals once a pillar falls
-	this.rules.Sync("ruins_portal_active", false);			  // If ruins have spawned portals or not.
+	this.rules.Sync("days_to_survive", true);
+	this.rules.Sync("curse_day", true);
+	this.rules.Sync("hardmode_day", true);
+	this.rules.Sync("ruins_portal_active", true);			  // If ruins have spawned portals or not.
 
 	// ----------------------------
 	// Flavor toggles
 	// ----------------------------
 	this.rules.set_bool("grave_spawn", true); // spawn graves with loot at markers
 	this.rules.set_bool("zombify", true);	  // allow players to zombify after death
+	this.rules.Sync("grave_spawn", true);
+	this.rules.Sync("zombify", true);
 
 											  // ----------------------------
 	// Debug logging (optional)
@@ -145,4 +168,14 @@ void RefreshMobCountsToRules()
 	rules.set_s32("zombiealter", num_alters);
 	rules.set_s32("num_survivors", num_survivors);
 	rules.set_s32("num_undead", num_undead);
+
+	const string[] props = {
+	"num_zombies", "num_pzombies", "num_migrantbots", "num_wraiths",
+	"num_gregs", "num_bisons", "num_ruinstorch", "num_zombiePortals",
+	"num_horror", "num_banshees", "num_gasbags", "num_abom",
+	"num_immol", "num_digger", "num_alters", "zombiealter",
+	"num_survivors", "num_undead"
+	};
+	for (uint i = 0; i < props.length; ++i)
+		rules.Sync(props[i], true);
 }

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -46,6 +46,7 @@ class ZombiesCore : RulesCore
 
 		// seed initial difficulty value
 		rules.set_f32("difficulty", 0.1f);
+		rules.Sync("difficulty", true);
 	}
 
 	void Update()
@@ -151,6 +152,7 @@ class ZombiesCore : RulesCore
 			{
 				wipeBonus += 0.5f;
 				rules.set_f32("difficulty_bonus", wipeBonus);
+				rules.Sync("difficulty_bonus", true);
 				rules.set_s32("last_wipe_day", dayNumber);
 
 				const float previewDifficulty = Maths::Min(
@@ -179,7 +181,8 @@ class ZombiesCore : RulesCore
 			difficulty = baseDifficulty;
 		if (difficulty > 50.0f)
 			difficulty = 50.0f; // expanded cap
-		rules.set_f32("difficulty", difficulty);
+			rules.set_f32("difficulty", difficulty);
+			rules.Sync("difficulty", true);
 
 		int spawnRate = 200 - int(difficulty * 3.3);
 		if (spawnRate < 15)
@@ -479,4 +482,4 @@ class ZombiesCore : RulesCore
 			// (score bookkeeping if needed)
 		}
 	}
-}
+	}

--- a/Rules/Scripts/Zombies/Zombies_Records.as
+++ b/Rules/Scripts/Zombies/Zombies_Records.as
@@ -22,6 +22,7 @@ void onInit(CRules @ this)
 	this.set_bool("dayCheated", false);
 	this.set_bool("records_saved", false);
 	this.set_bool("records_loaded", false);
+	this.Sync("dayCheated", true);
 }
 
 void onRestart(CRules @ this)
@@ -29,6 +30,7 @@ void onRestart(CRules @ this)
 	this.set_bool("dayCheated", false);
 	this.set_bool("records_saved", false);
 	this.set_bool("records_loaded", false);
+	this.Sync("dayCheated", true);
 }
 
 void LoadRecords(CRules @ this)


### PR DESCRIPTION
## Summary
- broadcast all global popup fields from the server so interface popups display properly
- sync rules config values and mob counters to clients so interface can rely on rules state
- ensure manual day skips and gamestart changes propagate to everyone

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68aa11056d508333a4833972ce55fc87