### PR TITLE
Remove include paths

### DIFF
--- a/Entities/Classes/SurvivorBuilder/BuilderHUD.as
+++ b/Entities/Classes/SurvivorBuilder/BuilderHUD.as
@@ -1,7 +1,7 @@
 // archer HUD
 // by The Sopranos
 
-#include "/Entities/Shared/GUI/nActorHUDStartPos.as";
+#include "nActorHUDStartPos.as";
 
 const string iconsFilename = "jclass.png";
 const int slotsSize = 6;

--- a/Entities/Classes/SurvivorBurd/BurdHUD.as
+++ b/Entities/Classes/SurvivorBurd/BurdHUD.as
@@ -1,7 +1,7 @@
 // burd HUD
 // by The Sopranos
 
-#include "/Entities/Shared/GUI/nActorHUDStartPos.as";
+#include "nActorHUDStartPos.as";
 
 const string iconsFilename = "jclass.png";
 const int slotsSize = 6;

--- a/Entities/Classes/SurvivorDragoon/DragoonHUD.as
+++ b/Entities/Classes/SurvivorDragoon/DragoonHUD.as
@@ -1,7 +1,7 @@
 // knight HUD
 // by The Sopranos
 
-#include "/Entities/Shared/GUI/nActorHUDStartPos.as";
+#include "nActorHUDStartPos.as";
 
 const string iconsFilename = "jclass.png";
 const int slotsSize = 6;

--- a/Entities/Classes/SurvivorKnight/KnightHUD.as
+++ b/Entities/Classes/SurvivorKnight/KnightHUD.as
@@ -1,7 +1,7 @@
 // knight HUD
 // by The Sopranos
 
-#include "/Entities/Shared/GUI/nActorHUDStartPos.as";
+#include "nActorHUDStartPos.as";
 
 const string iconsFilename = "jclass.png";
 const int slotsSize = 6;

--- a/Entities/Classes/UndeadBuilder/UndeadBuilderHUD.as
+++ b/Entities/Classes/UndeadBuilder/UndeadBuilderHUD.as
@@ -1,7 +1,7 @@
 // archer HUD
 // by The Sopranos
 
-#include "/Entities/Shared/GUI/nActorHUDStartPos.as";
+#include "nActorHUDStartPos.as";
 
 const string iconsFilename = "jclass.png";
 const int slotsSize = 6;

--- a/Entities/Classes/UndeadBunny/UndeadBunnyHUD.as
+++ b/Entities/Classes/UndeadBunny/UndeadBunnyHUD.as
@@ -1,7 +1,7 @@
 // archer HUD
 // by The Sopranos
 
-#include "/Entities/Shared/GUI/nActorHUDStartPos.as";
+#include "nActorHUDStartPos.as";
 
 const string iconsFilename = "jclass.png";
 const int slotsSize = 6;

--- a/Entities/Classes/UndeadGargoyle/UndeadGargoyleHUD.as
+++ b/Entities/Classes/UndeadGargoyle/UndeadGargoyleHUD.as
@@ -1,6 +1,6 @@
 // default actor hud
 //  a bar with hearts in the bottom left, bottom right free for actor specific stuff
-#include "/Entities/Shared/GUI/nActorHUDStartPos.as";
+#include "nActorHUDStartPos.as";
 const int slotsSize = 6;
 
 void renderBackBar(Vec2f origin, f32 width, f32 scale)

--- a/Entities/Classes/UndeadKnight/UndeadKnightHUD.as
+++ b/Entities/Classes/UndeadKnight/UndeadKnightHUD.as
@@ -1,7 +1,7 @@
 // knight HUD
 // by The Sopranos
 
-#include "/Entities/Shared/GUI/nActorHUDStartPos.as";
+#include "nActorHUDStartPos.as";
 
 const string iconsFilename = "jclass.png";
 const int slotsSize = 6;

--- a/Entities/Classes/UndeadSlayer/UndeadSlayerHUD.as
+++ b/Entities/Classes/UndeadSlayer/UndeadSlayerHUD.as
@@ -1,7 +1,7 @@
 // knight HUD
 // by The Sopranos
 
-#include "/Entities/Shared/GUI/nActorHUDStartPos.as";
+#include "nActorHUDStartPos.as";
 
 const string iconsFilename = "jclass.png";
 const int slotsSize = 6;

--- a/Entities/NPCs/Scripts/BotBrainCommon.as
+++ b/Entities/NPCs/Scripts/BotBrainCommon.as
@@ -1,6 +1,6 @@
 // brain
 
-#include "/Entities/Common/Emotes/EmotesCommon.as"
+#include "EmotesCommon.as"
 
 namespace Strategy
 {

--- a/Rules/Scripts/Core/GiveSpawnItems.as
+++ b/Rules/Scripts/Core/GiveSpawnItems.as
@@ -1,6 +1,6 @@
 // spawn resources
 
-#include "Core/Structs.as";
+#include "Structs.as";
 #include "RulesCore.as";
 
 const u32 materials_wait = 20;		  // seconds between free mats

--- a/Rules/Scripts/Core/Structs.as
+++ b/Rules/Scripts/Core/Structs.as
@@ -1,7 +1,7 @@
 // management structs
 
-#include "Rules/CommonScripts/BaseTeamInfo.as";
-#include "Rules/CommonScripts/PlayerInfo.as";
+#include "BaseTeamInfo.as";
+#include "PlayerInfo.as";
 
 namespace ItemFlag
 {

--- a/Rules/Scripts/Utilities/ChatCommands.as
+++ b/Rules/Scripts/Utilities/ChatCommands.as
@@ -7,7 +7,7 @@
 #include "MakeSeed.as";
 
 // #include "RPC_War.as";
-#include "Core/Structs.as";
+#include "Structs.as";
 #include "RulesCore.as";
 #include "WeatherSystem.as";
 

--- a/Rules/Scripts/Zombies/Zombies_Core.as
+++ b/Rules/Scripts/Zombies/Zombies_Core.as
@@ -1,5 +1,5 @@
 // Zombies_Core.as
-#include "Core/Structs.as"
+#include "Structs.as"
 #include "GlobalPopup.as"
 #include "RespawnSystem.as"
 #include "RulesCore.as"

--- a/Rules/Scripts/Zombies/Zombies_Interface.as
+++ b/Rules/Scripts/Zombies/Zombies_Interface.as
@@ -1,6 +1,6 @@
-#include "Core/Structs.as"
+#include "Structs.as"
 #include "GlobalPopup.as"
-#include "Scripts/Default/DefaultGUI.as"
+#include "DefaultGUI.as"
 
 // -------------------------------------
 //  Interface / HUD rendering

--- a/Rules/Scripts/Zombies/Zombies_Main.as
+++ b/Rules/Scripts/Zombies/Zombies_Main.as
@@ -1,7 +1,7 @@
 // Zombies_Main.as
 #define SERVER_ONLY
 
-#include "Core/Structs.as"
+#include "Structs.as"
 #include "RespawnSystem.as"
 #include "RulesCore.as"
 

--- a/Rules/Scripts/Zombies/Zombies_Spawns.as
+++ b/Rules/Scripts/Zombies/Zombies_Spawns.as
@@ -1,5 +1,5 @@
 // Zombies_Spawns.as
-#include "Core/Structs.as"
+#include "Structs.as"
 #include "RespawnSystem.as"
 #include "RulesCore.as"
 

--- a/Scripts/Default/DefaultStart.as
+++ b/Scripts/Default/DefaultStart.as
@@ -1,7 +1,7 @@
 // default startup functions for autostart scripts
 
-#include "Default/DefaultGUI.as"
-#include "Default/DefaultLoaders.as"
+#include "DefaultGUI.as"
+#include "DefaultLoaders.as"
 
 void RunServer()
 {


### PR DESCRIPTION
## Summary
- Remove directory paths from `#include` statements to use filenames only across HUD and rule scripts

## Testing
- `rg '#include\s+["<][^"<]*\/[^"<]*[">]' -n`


------
https://chatgpt.com/codex/tasks/task_e_68ab5d1569d88333a20893f3b8a0a4ab