### PR TITLE
Fix forge purchase issue by correcting script order

### DIFF
--- a/Entities/Shops/Forge/Forge.cfg
+++ b/Entities/Shops/Forge/Forge.cfg
@@ -71,8 +71,8 @@ $name                                      = forge
 											 DefaultBuilding.as;
 											 AlignToTiles.as;
 											 DecayInWater.as;
-											 Shop.as;
-											 Forge.as;
+                                                                                        Forge.as;
+                                                                                        Shop.as;
 											 StoneHit.as;
 											 Stone.as;
 											 BuildingEffects.as;


### PR DESCRIPTION
## Summary
- Correct Forge configuration so shop logic loads before shop scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7dfad59c833395aa1d0ccf464f53